### PR TITLE
Updated Location Headers returned to only send the arrival id

### DIFF
--- a/app/controllers/ArrivalsController.scala
+++ b/app/controllers/ArrivalsController.scala
@@ -85,7 +85,7 @@ class ArrivalsController @Inject()(cc: ControllerComponents,
 
   private def getLocationHeader(r: HttpResponse): Option[LocationHeader] =
   {
-    r.header(LOCATION).map(l => LocationHeader(l))
+    r.header(LOCATION).map(l => LocationHeader.parse(l))
   }
 
   private def urlEncode(s: String): String =

--- a/app/controllers/ArrivalsController.scala
+++ b/app/controllers/ArrivalsController.scala
@@ -45,17 +45,11 @@ class ArrivalsController @Inject()(cc: ControllerComponents,
             response.status match {
               case NO_CONTENT =>
                 getLocationHeader(response) match {
-                  case Some(locationHeader) => {
-                    (locationHeader.isEmpty, locationHeader.arrivalId, locationHeader.messageId) match {
-                      case (false, Some(a), Some(m)) =>
-                        Accepted.withHeaders(LOCATION -> s"/movements/arrivals/${urlEncode(a)}/messages/${urlEncode(m)}")
-                      case _ =>
-                        InternalServerError
-                    }
-                  }
-                  case _ =>
-                    InternalServerError
+                  case Some(lh) =>
+                    Accepted.withHeaders(LOCATION -> s"/movements/arrivals/${urlEncode(lh.arrivalId)}")
+                  case _ => InternalServerError
                 }
+              case _ => InternalServerError
             }
           } recover {
             case _: Throwable =>
@@ -74,15 +68,11 @@ class ArrivalsController @Inject()(cc: ControllerComponents,
               response.status match {
                 case NO_CONTENT =>
                   getLocationHeader(response) match {
-                    case Some(locationHeader) =>
-                      (locationHeader.isEmpty, locationHeader.arrivalId, locationHeader.messageId) match {
-                      case (false, Some(a), Some(m)) =>
-                        Accepted.withHeaders(LOCATION -> s"/movements/arrivals/${urlEncode(a)}/messages/${urlEncode(m)}")
-                      case _ =>
-                        InternalServerError
-                    }
+                    case Some(lh) =>
+                      Accepted.withHeaders(LOCATION -> s"/movements/arrivals/${urlEncode(lh.arrivalId)}")
                     case _ => InternalServerError
                   }
+                case _ => InternalServerError
               }
             } recover {
               case _: Throwable =>

--- a/app/controllers/ArrivalsController.scala
+++ b/app/controllers/ArrivalsController.scala
@@ -46,9 +46,9 @@ class ArrivalsController @Inject()(cc: ControllerComponents,
               case NO_CONTENT =>
                 getLocationHeader(response) match {
                   case Some(locationHeader) => {
-                    (locationHeader.isEmpty, locationHeader.arrivalId) match {
-                      case (false, Some(a)) =>
-                        Accepted.withHeaders(LOCATION -> s"/movements/arrivals/${urlEncode(a)}")
+                    (locationHeader.isEmpty, locationHeader.arrivalId, locationHeader.messageId) match {
+                      case (false, Some(a), Some(m)) =>
+                        Accepted.withHeaders(LOCATION -> s"/movements/arrivals/${urlEncode(a)}/messages/${urlEncode(m)}")
                       case _ =>
                         InternalServerError
                     }

--- a/app/controllers/LocationHeader.scala
+++ b/app/controllers/LocationHeader.scala
@@ -18,15 +18,13 @@ package controllers
 
 import java.net.URI
 
-case class LocationHeader(arrivalId: Option[String], messageId: Option[String]) {
-  def isEmpty = arrivalId.isEmpty && messageId.isEmpty
+sealed case class LocationHeader(arrivalId: String) {
+  def isEmpty = arrivalId.isEmpty
 }
 
 object LocationHeader {
   def apply(location: String): LocationHeader = {
     val split = new URI(location).getPath.split("/")
-    new LocationHeader(
-      if(split.length > 1) Some(split(2)) else None,
-      if(split.length > 3) Some(split(4)) else None)
+    LocationHeader(split.last)
   }
 }

--- a/app/controllers/LocationHeader.scala
+++ b/app/controllers/LocationHeader.scala
@@ -23,12 +23,12 @@ import play.api.libs.json.JsResult.Exception
 
 import scala.util.{Failure, Success, Try}
 
-sealed case class LocationHeader(arrivalId: String)
+case class LocationHeader(arrivalId: String)
 
 object LocationHeader {
-  def apply(location: String): LocationHeader = {
+  def parse(location: String): LocationHeader = {
     Try(new URI(location).getPath.split("/").last) match {
-      case Success(value) =>  LocationHeader(value)
+      case Success(value) =>  new LocationHeader(arrivalId = value)
       case Failure(_) => throw Exception(JsError(s"Unable to extract arrivalId from locationHeader: $location"))
     }
   }

--- a/app/controllers/LocationHeader.scala
+++ b/app/controllers/LocationHeader.scala
@@ -18,13 +18,18 @@ package controllers
 
 import java.net.URI
 
-sealed case class LocationHeader(arrivalId: String) {
-  def isEmpty = arrivalId.isEmpty
-}
+import play.api.libs.json.JsError
+import play.api.libs.json.JsResult.Exception
+
+import scala.util.{Failure, Success, Try}
+
+sealed case class LocationHeader(arrivalId: String)
 
 object LocationHeader {
   def apply(location: String): LocationHeader = {
-    val split = new URI(location).getPath.split("/")
-    LocationHeader(split.last)
+    Try(new URI(location).getPath.split("/").last) match {
+      case Success(value) =>  LocationHeader(value)
+      case Failure(_) => throw Exception(JsError(s"Unable to extract arrivalId from locationHeader: $location"))
+    }
   }
 }

--- a/test/controllers/ArrivalsControllerSpec.scala
+++ b/test/controllers/ArrivalsControllerSpec.scala
@@ -204,12 +204,12 @@ class ArrivalsControllerSpec extends FreeSpec with MustMatchers with GuiceOneApp
 
    "must return Accepted when successful" in {
      when(mockArrivalConnector.put(any(), any())(any(), any()))
-       .thenReturn(Future.successful( HttpResponse(responseStatus = NO_CONTENT, responseJson = None, responseHeaders = Map(LOCATION -> Seq("/arrivals/123/messages/4")), responseString = None) ))
+       .thenReturn(Future.successful( HttpResponse(responseStatus = NO_CONTENT, responseJson = None, responseHeaders = Map(LOCATION -> Seq("/arrivals/123")), responseString = None) ))
 
      val result = route(app, request).value
 
      status(result) mustBe ACCEPTED
-     headers(result) must contain (LOCATION -> "/movements/arrivals/123/messages/4")
+     headers(result) must contain (LOCATION -> "/movements/arrivals/123")
    }
 
    "must return InternalServerError when unsuccessful" in {
@@ -245,16 +245,16 @@ class ArrivalsControllerSpec extends FreeSpec with MustMatchers with GuiceOneApp
 
      val result = route(app, request).value
      status(result) mustBe ACCEPTED
-     headers(result) must contain (LOCATION -> "/movements/arrivals/123-%40%2B*%7E-31%40/messages/123-%40%2B*%7E-31%40")
+     headers(result) must contain (LOCATION -> "/movements/arrivals/123-%40%2B*%7E-31%40")
    }
 
    "must exclude query string if present in downstream Location header" in {
      when(mockArrivalConnector.put(any(), any())(any(), any()))
-       .thenReturn(Future.successful( HttpResponse(responseStatus = NO_CONTENT, responseJson = None, responseHeaders = Map(LOCATION -> Seq("/arrivals/123/messages/4?status=success")), responseString = None) ))
+       .thenReturn(Future.successful( HttpResponse(responseStatus = NO_CONTENT, responseJson = None, responseHeaders = Map(LOCATION -> Seq("/arrivals/123?status=success")), responseString = None) ))
 
      val result = route(app, request).value
      status(result) mustBe ACCEPTED
-     headers(result) must contain (LOCATION -> "/movements/arrivals/123/messages/4")
+     headers(result) must contain (LOCATION -> "/movements/arrivals/123")
    }
 
    "must return UnsupportedMediaType when Content-Type is JSON" in {


### PR DESCRIPTION
Changed response headers to match /arrivals/{arrivalId} expectation. Simplified LocationHeader to be less prone to issues and to match new location headers received.

Built to work against this stub branch : https://github.com/hmrc/transit-movements-trader-at-destination-stub/tree/CTDA-83-message-addition