### PR TITLE
Specify correct content type in MessageConnector

### DIFF
--- a/app/connectors/ArrivalConnector.scala
+++ b/app/connectors/ArrivalConnector.scala
@@ -25,25 +25,22 @@ import uk.gov.hmrc.play.bootstrap.http.HttpClient
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class ArrivalConnector @Inject()(http: HttpClient, appConfig: AppConfig) {
+class ArrivalConnector @Inject()(http: HttpClient, appConfig: AppConfig) extends BaseConnector {
 
   val arrivalRoute = "/transit-movements-trader-at-destination/movements/arrivals/"
 
-  private def headers()(implicit hc: HeaderCarrier): Seq[(String, String)] =
-    hc.headers ++ Seq((HeaderNames.CONTENT_TYPE, MimeTypes.XML))
-
   def post(message: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = {
     val url = appConfig.traderAtDestinationUrl + arrivalRoute
-    http.POSTString(url, message, headers())(CustomHttpReader, hc, implicitly)
+    http.POSTString(url, message, requestHeaders())(CustomHttpReader, hc, implicitly)
   }
 
   def post(message: String, arrivalId: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = {
     val url = appConfig.traderAtDestinationUrl + arrivalRoute + arrivalId
-    http.POSTString(url, message, headers())(CustomHttpReader, hc, implicitly)
+    http.POSTString(url, message, requestHeaders())(CustomHttpReader, hc, implicitly)
   }
 
   def put(message: String, arrivalId: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = {
     val url = appConfig.traderAtDestinationUrl + arrivalRoute + arrivalId
-    http.PUTString(url, message, headers())(CustomHttpReader, hc, implicitly)
+    http.PUTString(url, message, requestHeaders())(CustomHttpReader, hc, implicitly)
   }
 }

--- a/app/connectors/BaseConnector.scala
+++ b/app/connectors/BaseConnector.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import play.mvc.Http.{HeaderNames, MimeTypes}
+import uk.gov.hmrc.http.HeaderCarrier
+
+trait BaseConnector {
+  protected def requestHeaders()(implicit hc: HeaderCarrier): Seq[(String, String)] =
+    hc.headers ++ Seq((HeaderNames.CONTENT_TYPE, MimeTypes.XML))
+
+  protected def responseHeaders()(implicit hc: HeaderCarrier): Seq[(String, String)] =
+    hc.headers ++ Seq((HeaderNames.CONTENT_TYPE, MimeTypes.JSON))
+}

--- a/app/connectors/MessageConnector.scala
+++ b/app/connectors/MessageConnector.scala
@@ -27,13 +27,13 @@ import uk.gov.hmrc.play.bootstrap.http.HttpClient
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class MessageConnector @Inject()(http: HttpClient, appConfig: AppConfig) extends HttpErrorFunctions {
+class MessageConnector @Inject()(http: HttpClient, appConfig: AppConfig) extends BaseConnector with HttpErrorFunctions {
 
   val rootUrl = appConfig.traderAtDestinationUrl + "/transit-movements-trader-at-destination/movements"
 
   def get(arrivalId: String, messageId: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Either[HttpResponse, MovementMessage]] = {
     val url = rootUrl + s"/arrivals/$arrivalId/messages/$messageId"
-    http.GET[HttpResponse](url, queryParams = Seq(), headers = Seq(HeaderNames.CONTENT_TYPE -> "application/json"))(CustomHttpReader, implicitly, implicitly).map { r =>
+    http.GET[HttpResponse](url, queryParams = Seq(), responseHeaders())(CustomHttpReader, implicitly, implicitly).map { r =>
       if(is2xx(r.status)) {
         r.json.asOpt[MovementMessage] match {
           case Some(x) => Right(x)
@@ -45,6 +45,6 @@ class MessageConnector @Inject()(http: HttpClient, appConfig: AppConfig) extends
 
   def post(message: String, arrivalId: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = {
     val url = rootUrl + s"/arrivals/$arrivalId/messages"
-    http.POSTString(url, message, Seq(HeaderNames.CONTENT_TYPE -> "application/xml"))(CustomHttpReader, implicitly, implicitly)
+    http.POSTString(url, message, requestHeaders())(CustomHttpReader, implicitly, implicitly)
   }
 }

--- a/app/connectors/MessageConnector.scala
+++ b/app/connectors/MessageConnector.scala
@@ -21,6 +21,7 @@ import connectors.util.CustomHttpReader
 import connectors.util.CustomHttpReader.INTERNAL_SERVER_ERROR
 import javax.inject.Inject
 import models.domain.MovementMessage
+import play.api.http.HeaderNames
 import uk.gov.hmrc.http.{HeaderCarrier, HttpErrorFunctions, HttpResponse}
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
 
@@ -32,7 +33,7 @@ class MessageConnector @Inject()(http: HttpClient, appConfig: AppConfig) extends
 
   def get(arrivalId: String, messageId: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Either[HttpResponse, MovementMessage]] = {
     val url = rootUrl + s"/arrivals/$arrivalId/messages/$messageId"
-    http.GET[HttpResponse](url)(CustomHttpReader, implicitly, implicitly).map { r =>
+    http.GET[HttpResponse](url, queryParams = Seq(), headers = Seq(HeaderNames.CONTENT_TYPE -> "application/json"))(CustomHttpReader, implicitly, implicitly).map { r =>
       if(is2xx(r.status)) {
         r.json.asOpt[MovementMessage] match {
           case Some(x) => Right(x)
@@ -44,6 +45,6 @@ class MessageConnector @Inject()(http: HttpClient, appConfig: AppConfig) extends
 
   def post(message: String, arrivalId: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = {
     val url = rootUrl + s"/arrivals/$arrivalId/messages"
-    http.POSTString(url, message)(CustomHttpReader, implicitly, implicitly)
+    http.POSTString(url, message, Seq(HeaderNames.CONTENT_TYPE -> "application/xml"))(CustomHttpReader, implicitly, implicitly)
   }
 }

--- a/test/data/TestXml.scala
+++ b/test/data/TestXml.scala
@@ -89,7 +89,7 @@ trait TestXml {
       <MesRecMES6>111111</MesRecMES6>
       <!--Optional:-->
       <RecIdeCodQuaMES7>1111</RecIdeCodQuaMES7>
-      <DatOfPreMES9>111111</DatOfPreMES9>
+      <DatOfPreMES9>20001001</DatOfPreMES9>
       <TimOfPreMES10>1111</TimOfPreMES10>
       <IntConRefMES11>111111</IntConRefMES11>
       <!--Optional:-->


### PR DESCRIPTION
MessageConnector wasn't sending the correct content type in the header so downstream was responding with 415 Unsupported Media Type.<br><br>The CC044A example in TestXml has also been updated to contain the correct date field as downstream was failing with BadRequest without it.