### PR TITLE
spike to add ni-function

### DIFF
--- a/app/audit/AuditDetails.scala
+++ b/app/audit/AuditDetails.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/audit/AuditService.scala
+++ b/app/audit/AuditService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/audit/AuditType.scala
+++ b/app/audit/AuditType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/config/Constants.scala
+++ b/app/config/Constants.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/config/Module.scala
+++ b/app/config/Module.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/connectors/ArrivalConnector.scala
+++ b/app/connectors/ArrivalConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/connectors/ArrivalMessageConnector.scala
+++ b/app/connectors/ArrivalMessageConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/connectors/BaseConnector.scala
+++ b/app/connectors/BaseConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/connectors/DepartureMessageConnector.scala
+++ b/app/connectors/DepartureMessageConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/connectors/DeparturesConnector.scala
+++ b/app/connectors/DeparturesConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/connectors/util/CustomHttpReader.scala
+++ b/app/connectors/util/CustomHttpReader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/ArrivalMessagesController.scala
+++ b/app/controllers/ArrivalMessagesController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/ArrivalMovementController.scala
+++ b/app/controllers/ArrivalMovementController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/DepartureMessagesController.scala
+++ b/app/controllers/DepartureMessagesController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/DeparturesController.scala
+++ b/app/controllers/DeparturesController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/actions/AuthAction.scala
+++ b/app/controllers/actions/AuthAction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/actions/AuthRequest.scala
+++ b/app/controllers/actions/AuthRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/actions/EnsureGuaranteeAction.scala
+++ b/app/controllers/actions/EnsureGuaranteeAction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/actions/ValidateAcceptJsonHeaderAction.scala
+++ b/app/controllers/actions/ValidateAcceptJsonHeaderAction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/actions/ValidateArrivalMessageAction.scala
+++ b/app/controllers/actions/ValidateArrivalMessageAction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/actions/ValidateArrivalNotificationAction.scala
+++ b/app/controllers/actions/ValidateArrivalNotificationAction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/actions/ValidateDepartureDeclarationAction.scala
+++ b/app/controllers/actions/ValidateDepartureDeclarationAction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/actions/ValidateDepartureMessageAction.scala
+++ b/app/controllers/actions/ValidateDepartureMessageAction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/documentation/DocumentationController.scala
+++ b/app/controllers/documentation/DocumentationController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/ChannelType.scala
+++ b/app/models/ChannelType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/Enumerable.scala
+++ b/app/models/Enumerable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/GOOITEGDSNode.scala
+++ b/app/models/GOOITEGDSNode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/Guarantee.scala
+++ b/app/models/Guarantee.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/IeMetadata.scala
+++ b/app/models/IeMetadata.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/MessageType.scala
+++ b/app/models/MessageType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/Offices.scala
+++ b/app/models/Offices.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,9 @@
 
 package models
 
-abstract class Office(value: String)
+abstract class Office(value: String) {
+  def prefix = value.substring(0,2)
+}
 
 final case class DepartureOffice(value: String) extends Office(value: String)
 final case class DestinationOffice(value: String) extends Office(value: String)

--- a/app/models/ParseError.scala
+++ b/app/models/ParseError.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/ParseHandler.scala
+++ b/app/models/ParseHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/SpecialMentionGuarantee.scala
+++ b/app/models/SpecialMentionGuarantee.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/SpecialMentionGuaranteeDetails.scala
+++ b/app/models/SpecialMentionGuaranteeDetails.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/TransformInstruction.scala
+++ b/app/models/TransformInstruction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/domain/Arrival.scala
+++ b/app/models/domain/Arrival.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/domain/ArrivalWithMessages.scala
+++ b/app/models/domain/ArrivalWithMessages.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/domain/Arrivals.scala
+++ b/app/models/domain/Arrivals.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/domain/Departure.scala
+++ b/app/models/domain/Departure.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/domain/DepartureWithMessages.scala
+++ b/app/models/domain/DepartureWithMessages.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/domain/Departures.scala
+++ b/app/models/domain/Departures.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/domain/MovementMessage.scala
+++ b/app/models/domain/MovementMessage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/request/GuaranteedRequest.scala
+++ b/app/models/request/GuaranteedRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/request/XSDFile.scala
+++ b/app/models/request/XSDFile.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/response/HateaosArrivalMessagesPostResponseMessage.scala
+++ b/app/models/response/HateaosArrivalMessagesPostResponseMessage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/response/HateaosArrivalMovementPostResponseMessage.scala
+++ b/app/models/response/HateaosArrivalMovementPostResponseMessage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/response/HateaosArrivalResponseMessage.scala
+++ b/app/models/response/HateaosArrivalResponseMessage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/response/HateaosDepartureMessagesPostResponseMessage.scala
+++ b/app/models/response/HateaosDepartureMessagesPostResponseMessage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/response/HateaosDeparturePostResponseMessage.scala
+++ b/app/models/response/HateaosDeparturePostResponseMessage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/response/HateaosDepartureResponseMessage.scala
+++ b/app/models/response/HateaosDepartureResponseMessage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/response/HateaosResponseArrival.scala
+++ b/app/models/response/HateaosResponseArrival.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/response/HateaosResponseArrivalWithMessages.scala
+++ b/app/models/response/HateaosResponseArrivalWithMessages.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/response/HateaosResponseArrivals.scala
+++ b/app/models/response/HateaosResponseArrivals.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/response/HateaosResponseDeparture.scala
+++ b/app/models/response/HateaosResponseDeparture.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/response/HateaosResponseDepartureWithMessages.scala
+++ b/app/models/response/HateaosResponseDepartureWithMessages.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/response/HateaosResponseDepartures.scala
+++ b/app/models/response/HateaosResponseDepartures.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/services/EnsureGuaranteeService.scala
+++ b/app/services/EnsureGuaranteeService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/services/XmlValidationService.scala
+++ b/app/services/XmlValidationService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/utils/CallOps.scala
+++ b/app/utils/CallOps.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/utils/JsonHelper.scala
+++ b/app/utils/JsonHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/utils/MessageTranslation.scala
+++ b/app/utils/MessageTranslation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/utils/NodeSeqFormat.scala
+++ b/app/utils/NodeSeqFormat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/utils/ResponseHelper.scala
+++ b/app/utils/ResponseHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/utils/Utils.scala
+++ b/app/utils/Utils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/utils/guaranteeParsing/GuaranteeXmlReaders.scala
+++ b/app/utils/guaranteeParsing/GuaranteeXmlReaders.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/utils/guaranteeParsing/InstructionBuilder.scala
+++ b/app/utils/guaranteeParsing/InstructionBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/utils/guaranteeParsing/RouteChecker.scala
+++ b/app/utils/guaranteeParsing/RouteChecker.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,15 +31,13 @@ class RouteChecker @Inject()(xmlReaders: GuaranteeXmlReaders) {
         xmlReaders.officeOfDestination(xml) match {
           case Left(error) => Left(error)
           case Right(destination) => {
-            if(departure.value.startsWith("GB")){
-              Right(destination.value.startsWith("GB"))
-            }
-            else {
-              Left(InappropriateDepartureOffice("Inappropriate Departure Office"))
+            departure.prefix match {
+              case "GB" => Right(destination.value.startsWith("GB"))
+              case "XI" => Right(false)
+              case _ => Left(InappropriateDepartureOffice("Inappropriate Departure Office"))
             }
           }
         }
       }
     }
-
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2020 HM Revenue & Customs
+# Copyright 2021 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/audit/AuditServiceSpec.scala
+++ b/test/audit/AuditServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/connectors/BaseConnectorSpec.scala
+++ b/test/connectors/BaseConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/connectors/util/CustomHttpReaderSpec.scala
+++ b/test/connectors/util/CustomHttpReaderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/ArrivalMessagesControllerSpec.scala
+++ b/test/controllers/ArrivalMessagesControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/ArrivalMovementControllerSpec.scala
+++ b/test/controllers/ArrivalMovementControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/DepartureMessagesControllerSpec.scala
+++ b/test/controllers/DepartureMessagesControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/DeparturesControllerSpec.scala
+++ b/test/controllers/DeparturesControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/actions/AuthActionSpec.scala
+++ b/test/controllers/actions/AuthActionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/actions/FakeAuthAction.scala
+++ b/test/controllers/actions/FakeAuthAction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/actions/ValidateAcceptJsonHeaderActionSpec.scala
+++ b/test/controllers/actions/ValidateAcceptJsonHeaderActionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/actions/ValidateArrivalMessageActionSpec.scala
+++ b/test/controllers/actions/ValidateArrivalMessageActionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/actions/ValidateArrivalNotificationActionSpec.scala
+++ b/test/controllers/actions/ValidateArrivalNotificationActionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/actions/ValidateDepartureDeclarationActionSpec.scala
+++ b/test/controllers/actions/ValidateDepartureDeclarationActionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/actions/ValidateDepartureMessageActionSpec.scala
+++ b/test/controllers/actions/ValidateDepartureMessageActionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/data/TestXml.scala
+++ b/test/data/TestXml.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/models/ParseErrorSpec.scala
+++ b/test/models/ParseErrorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/models/SpecialMentionGuaranteeSpec.scala
+++ b/test/models/SpecialMentionGuaranteeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/models/request/XSDFileSpec.scala
+++ b/test/models/request/XSDFileSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/models/response/HateaosArrivalMessagesPostResponseMessageSpec.scala
+++ b/test/models/response/HateaosArrivalMessagesPostResponseMessageSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/models/response/HateaosArrivalMovementPostResponseMessageSpec.scala
+++ b/test/models/response/HateaosArrivalMovementPostResponseMessageSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/models/response/HateaosArrivalResponseMessageSpec.scala
+++ b/test/models/response/HateaosArrivalResponseMessageSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/models/response/HateaosDepartureMessagesPostResponseMessageSpec.scala
+++ b/test/models/response/HateaosDepartureMessagesPostResponseMessageSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/models/response/HateaosDeparturePostResponseMessageSpec.scala
+++ b/test/models/response/HateaosDeparturePostResponseMessageSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/models/response/HateaosDepartureResponseMessageSpec.scala
+++ b/test/models/response/HateaosDepartureResponseMessageSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/models/response/HateaosResponseArrivalSpec.scala
+++ b/test/models/response/HateaosResponseArrivalSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/models/response/HateaosResponseArrivalWithMessagesSpec.scala
+++ b/test/models/response/HateaosResponseArrivalWithMessagesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/models/response/HateaosResponseDepartureSpec.scala
+++ b/test/models/response/HateaosResponseDepartureSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/models/response/HateaosResponseDepartureWithMessagesSpec.scala
+++ b/test/models/response/HateaosResponseDepartureWithMessagesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/services/EnsureGuaranteeServiceSpec.scala
+++ b/test/services/EnsureGuaranteeServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/services/XmlValidationServiceSpec.scala
+++ b/test/services/XmlValidationServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/utils/JsonHelperSpec.scala
+++ b/test/utils/JsonHelperSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/utils/MessageTranslationSpec.scala
+++ b/test/utils/MessageTranslationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/utils/ResponseHelperSpec.scala
+++ b/test/utils/ResponseHelperSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/utils/guaranteeParsing/GuaranteeXmlReadersSpec.scala
+++ b/test/utils/guaranteeParsing/GuaranteeXmlReadersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/utils/guaranteeParsing/InstructionBuilderSpec.scala
+++ b/test/utils/guaranteeParsing/InstructionBuilderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/utils/guaranteeParsing/RouteCheckerSpec.scala
+++ b/test/utils/guaranteeParsing/RouteCheckerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,7 +75,7 @@ class RouteCheckerSpec  extends AnyFreeSpec with ParseHandling with MockitoSugar
       sut.gbOnlyCheck(<example></example>) mustBe a[Left[DestinationEmpty, _]]
     }
 
-    "returns InappropriateDepartureOffice if we DepartureOffice doesn't start with GB" in {
+    "returns InappropriateDepartureOffice if we DepartureOffice doesn't start with GB or XI" in {
       when(mockXmlReaders.officeOfDeparture)
         .thenReturn(ReaderT[ParseHandler, NodeSeq, DepartureOffice](_ => Right(DepartureOffice("UKabc"))))
       when(mockXmlReaders.officeOfDestination)
@@ -104,6 +104,18 @@ class RouteCheckerSpec  extends AnyFreeSpec with ParseHandling with MockitoSugar
       val result = sut.gbOnlyCheck(<example></example>)
       result mustBe a[Right[_ ,Boolean]]
       result.right.get mustBe true
+    }
+
+    "returns Right(false) if DepartureOffice starts with XI" in {
+      when(mockXmlReaders.officeOfDeparture)
+        .thenReturn(ReaderT[ParseHandler, NodeSeq, DepartureOffice](_ => Right(DepartureOffice("XIabc"))))
+      when(mockXmlReaders.officeOfDestination)
+        .thenReturn(ReaderT[ParseHandler, NodeSeq, DestinationOffice](_ => Right(DestinationOffice("ITabc"))))
+
+      val result = sut.gbOnlyCheck(<example></example>)
+      result mustBe a[Right[_ ,Boolean]]
+      result.right.get mustBe false
+
     }
   }
 

--- a/test/xml/CC007ASpec.scala
+++ b/test/xml/CC007ASpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/xml/CC014ASpec.scala
+++ b/test/xml/CC014ASpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/xml/CC015BSpec.scala
+++ b/test/xml/CC015BSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/xml/CC044ASpec.scala
+++ b/test/xml/CC044ASpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
updates the 2020-2021 docs
also updates the routechecker to return a right of false when an XI Departure office is provided so that the guarantee will be applied