### PR TITLE
CTDA-1281 Add metrics collection to controllers and connectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ test-result
 tmp
 .idea_modules
 bin
+.bloop/
+.bsp/
+.metals/
+.vscode/
+metals.sbt

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,44 @@
+version = "2.7.5"
+
+// Sets max amount of characters before new line
+maxColumn = 160
+
+// Sets indentation of method arguments and parameters
+continuationIndent {
+  callSite = 2
+  defnSite = 2
+}
+
+// Aligns tokens for numerous methods e.g. matchers, for yield and module ID's
+align = more
+
+
+// PreferCurlyFors        - Replaces parentheses into curly braces in for comprehensions that contain multiple enumerator generators.
+// RedundantBraces        - Removes redundant brances
+// RedundantParens        - Removes reduanant parentheses, including those within string interpolation
+// SortModifiers          - Sorts modifiers alphabetically
+// ExpandImportSelectors  - Adds collapsed imports into new imports
+rewrite {
+  rules = [PreferCurlyFors, RedundantBraces, RedundantParens, SortModifiers, ExpandImportSelectors]
+  redundantBraces {
+    stringInterpolation = true
+  }
+}
+
+newlines {
+  alwaysBeforeTopLevelStatements = true
+  alwaysBeforeCurlyBraceLambdaParams = true
+}
+
+// Adds breaks between large lists
+binPack.literalArgumentLists = true
+
+includeCurlyBraceInSelectChains = true
+optIn.breakChainOnFirstMethodDot = true
+
+rewriteTokens {
+  "\t": "  "
+  "→": "->"
+  "←": "<-"
+  "⇒": "=>"
+}

--- a/app/connectors/ArrivalConnector.scala
+++ b/app/connectors/ArrivalConnector.scala
@@ -21,7 +21,7 @@ import javax.inject.Inject
 import com.kenshoo.play.metrics.Metrics
 import config.AppConfig
 import connectors.util.CustomHttpReader
-import metrics.HasMetrics
+import metrics.{HasMetrics, MetricsKeys}
 import models.domain.Arrival
 import models.domain.Arrivals
 import play.api.mvc.RequestHeader
@@ -33,20 +33,22 @@ import scala.concurrent.Future
 
 class ArrivalConnector @Inject() (http: HttpClient, appConfig: AppConfig, val metrics: Metrics) extends BaseConnector with HasMetrics {
 
+  import MetricsKeys.ArrivalBackend._
+
   def post(message: String)(implicit requestHeader: RequestHeader, hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] =
-    withMetricsTimerResponse("arrival-backend-post") {
+    withMetricsTimerResponse(Post) {
       val url = appConfig.traderAtDestinationUrl + arrivalRoute
       http.POSTString(url, message)(CustomHttpReader, enforceAuthHeaderCarrier(requestHeaders), ec)
     }
 
   def put(message: String, arrivalId: String)(implicit requestHeader: RequestHeader, headerCarrier: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] =
-    withMetricsTimerResponse("arrival-backend-put") {
+    withMetricsTimerResponse(Put) {
       val url = appConfig.traderAtDestinationUrl + arrivalRoute + Utils.urlEncode(arrivalId)
       http.PUTString(url, message)(CustomHttpReader, enforceAuthHeaderCarrier(requestHeaders), ec)
     }
 
   def get(arrivalId: String)(implicit requestHeader: RequestHeader, hc: HeaderCarrier, ec: ExecutionContext): Future[Either[HttpResponse, Arrival]] =
-    withMetricsTimerAsync("arrival-backend-get-by-id") {
+    withMetricsTimerAsync(GetById) {
       timer =>
         val url = appConfig.traderAtDestinationUrl + arrivalRoute + Utils.urlEncode(arrivalId)
         http.GET[HttpResponse](url, queryParams = Seq(), responseHeaders)(CustomHttpReader, enforceAuthHeaderCarrier(responseHeaders), ec).map {
@@ -57,7 +59,7 @@ class ArrivalConnector @Inject() (http: HttpClient, appConfig: AppConfig, val me
     }
 
   def getForEori()(implicit requestHeader: RequestHeader, hc: HeaderCarrier, ec: ExecutionContext): Future[Either[HttpResponse, Arrivals]] =
-    withMetricsTimerAsync("arrival-backend-get-for-eori") {
+    withMetricsTimerAsync(GetForEori) {
       timer =>
         val url = appConfig.traderAtDestinationUrl + arrivalRoute
         http.GET[HttpResponse](url, queryParams = Seq(), responseHeaders)(CustomHttpReader, enforceAuthHeaderCarrier(responseHeaders), ec).map {

--- a/app/connectors/ArrivalMessageConnector.scala
+++ b/app/connectors/ArrivalMessageConnector.scala
@@ -16,39 +16,57 @@
 
 package connectors
 
+import javax.inject.Inject
+
+import com.kenshoo.play.metrics.Metrics
 import config.AppConfig
 import connectors.util.CustomHttpReader
-import javax.inject.Inject
-import models.domain.{ArrivalWithMessages, MovementMessage}
+import metrics.HasMetrics
+import models.domain.ArrivalWithMessages
+import models.domain.MovementMessage
 import play.api.mvc.RequestHeader
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
-import uk.gov.hmrc.play.bootstrap.http.HttpClient
+import uk.gov.hmrc.http.HttpClient
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.HttpResponse
 import utils.Utils
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 
-class ArrivalMessageConnector @Inject()(http: HttpClient, appConfig: AppConfig) extends BaseConnector {
+class ArrivalMessageConnector @Inject() (http: HttpClient, appConfig: AppConfig, val metrics: Metrics) extends BaseConnector with HasMetrics {
 
-  def get(arrivalId: String, messageId: String)(implicit requestHeader: RequestHeader, hc: HeaderCarrier, ec: ExecutionContext): Future[Either[HttpResponse, MovementMessage]] = {
-    val url = appConfig.traderAtDestinationUrl + s"$arrivalRoute${Utils.urlEncode(arrivalId)}/messages/${Utils.urlEncode(messageId)}"
-
-    http.GET[HttpResponse](url, queryParams = Seq(), responseHeaders)(CustomHttpReader, enforceAuthHeaderCarrier(responseHeaders), ec).map { response =>
-      extractIfSuccessful[MovementMessage](response)
+  def get(arrivalId: String, messageId: String)(implicit
+    requestHeader: RequestHeader,
+    hc: HeaderCarrier,
+    ec: ExecutionContext
+  ): Future[Either[HttpResponse, MovementMessage]] =
+    withMetricsTimerAsync("arrival-backend-get-message-by-id") {
+      timer =>
+        val url = appConfig.traderAtDestinationUrl + s"$arrivalRoute${Utils.urlEncode(arrivalId)}/messages/${Utils.urlEncode(messageId)}"
+        http.GET[HttpResponse](url, queryParams = Seq(), responseHeaders)(CustomHttpReader, enforceAuthHeaderCarrier(responseHeaders), ec).map {
+          response =>
+            if (is2xx(response.status)) timer.completeWithSuccess() else timer.completeWithFailure()
+            extractIfSuccessful[MovementMessage](response)
+        }
     }
-  }
 
-  def post(message: String, arrivalId: String)(implicit requestHeader: RequestHeader, hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = {
-    val url = appConfig.traderAtDestinationUrl + s"$arrivalRoute${Utils.urlEncode(arrivalId)}/messages"
-
-    http.POSTString(url, message, requestHeaders)(CustomHttpReader, enforceAuthHeaderCarrier(requestHeaders), ec)
-  }
-
-  def getMessages(arrivalId: String)(implicit requestHeader: RequestHeader, hc: HeaderCarrier, ec: ExecutionContext): Future[Either[HttpResponse, ArrivalWithMessages]] = {
-    val url = appConfig.traderAtDestinationUrl + s"$arrivalRoute${Utils.urlEncode(arrivalId)}/messages"
-
-    http.GET[HttpResponse](url, queryParams = Seq(), responseHeaders)(CustomHttpReader, enforceAuthHeaderCarrier(responseHeaders), ec).map { response =>
-      extractIfSuccessful[ArrivalWithMessages](response)
+  def post(message: String, arrivalId: String)(implicit requestHeader: RequestHeader, hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] =
+    withMetricsTimerResponse("arrival-backend-post-message") {
+      val url = appConfig.traderAtDestinationUrl + s"$arrivalRoute${Utils.urlEncode(arrivalId)}/messages"
+      http.POSTString(url, message, requestHeaders)(CustomHttpReader, enforceAuthHeaderCarrier(requestHeaders), ec)
     }
-  }
+
+  def getMessages(
+    arrivalId: String
+  )(implicit requestHeader: RequestHeader, hc: HeaderCarrier, ec: ExecutionContext): Future[Either[HttpResponse, ArrivalWithMessages]] =
+    withMetricsTimerAsync("arrival-backend-get-messages-for-arrival") {
+      timer =>
+        val url = appConfig.traderAtDestinationUrl + s"$arrivalRoute${Utils.urlEncode(arrivalId)}/messages"
+        http.GET[HttpResponse](url, queryParams = Seq(), responseHeaders)(CustomHttpReader, enforceAuthHeaderCarrier(responseHeaders), ec).map {
+          response =>
+            if (is2xx(response.status)) timer.completeWithSuccess() else timer.completeWithFailure()
+            extractIfSuccessful[ArrivalWithMessages](response)
+        }
+    }
 
 }

--- a/app/connectors/DeparturesConnector.scala
+++ b/app/connectors/DeparturesConnector.scala
@@ -21,7 +21,7 @@ import javax.inject.Inject
 import com.kenshoo.play.metrics.Metrics
 import config.AppConfig
 import connectors.util.CustomHttpReader
-import metrics.HasMetrics
+import metrics.{HasMetrics, MetricsKeys}
 import models.domain.Departure
 import models.domain.Departures
 import play.api.mvc.RequestHeader
@@ -30,19 +30,21 @@ import uk.gov.hmrc.http.HttpResponse
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
 import utils.Utils
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.Future
 
 class DeparturesConnector @Inject() (http: HttpClient, appConfig: AppConfig, val metrics: Metrics) extends BaseConnector with HasMetrics {
 
+  import MetricsKeys.DeparturesBackend._
+
   def post(message: String)(implicit requestHeader: RequestHeader, hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] =
-    withMetricsTimerResponse("departures-backend-post") {
+    withMetricsTimerResponse(Post) {
       val url = appConfig.traderAtDeparturesUrl + departureRoute
       http.POSTString(url, message)(CustomHttpReader, enforceAuthHeaderCarrier(requestHeaders), ec)
     }
 
   def get(departureId: String)(implicit requestHeader: RequestHeader, hc: HeaderCarrier, ec: ExecutionContext): Future[Either[HttpResponse, Departure]] =
-    withMetricsTimerAsync("departures-backend-get-by-id") {
+    withMetricsTimerAsync(GetById) {
       timer =>
         val url = appConfig.traderAtDeparturesUrl + departureRoute + Utils.urlEncode(departureId)
         http.GET[HttpResponse](url, queryParams = Seq(), responseHeaders)(CustomHttpReader, enforceAuthHeaderCarrier(responseHeaders), ec).map {
@@ -53,7 +55,7 @@ class DeparturesConnector @Inject() (http: HttpClient, appConfig: AppConfig, val
     }
 
   def getForEori()(implicit requestHeader: RequestHeader, hc: HeaderCarrier, ec: ExecutionContext): Future[Either[HttpResponse, Departures]] =
-    withMetricsTimerAsync("departures-backend-get-for-eori") {
+    withMetricsTimerAsync(GetForEori) {
       timer =>
         val url = appConfig.traderAtDeparturesUrl + departureRoute
 

--- a/app/controllers/ArrivalMessagesController.scala
+++ b/app/controllers/ArrivalMessagesController.scala
@@ -16,77 +16,102 @@
 
 package controllers
 
-import connectors.ArrivalMessageConnector
-import controllers.actions.{AuthAction, ValidateAcceptJsonHeaderAction, ValidateArrivalMessageAction}
-import models.MessageType
-
 import javax.inject.Inject
-import models.response.{HateaosArrivalMessagesPostResponseMessage, HateaosArrivalResponseMessage, HateaosResponseArrivalWithMessages}
+
+import com.kenshoo.play.metrics.Metrics
+import connectors.ArrivalMessageConnector
+import controllers.actions.AuthAction
+import controllers.actions.ValidateAcceptJsonHeaderAction
+import controllers.actions.ValidateArrivalMessageAction
+import metrics.HasActionMetrics
+import models.MessageType
+import models.response.HateaosArrivalMessagesPostResponseMessage
+import models.response.HateaosArrivalResponseMessage
+import models.response.HateaosResponseArrivalWithMessages
 import play.api.libs.json.Json
-import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.ControllerComponents
 import uk.gov.hmrc.http.HttpErrorFunctions
-import uk.gov.hmrc.play.bootstrap.controller.BackendController
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import utils.CallOps._
-import utils.{ResponseHelper, Utils}
+import utils.ResponseHelper
+import utils.Utils
 
 import scala.concurrent.ExecutionContext
 import scala.xml.NodeSeq
 
-class ArrivalMessagesController @Inject()(cc: ControllerComponents,
-                                          authAction: AuthAction,
-                                          messageConnector: ArrivalMessageConnector,
-                                          validateMessageAction: ValidateArrivalMessageAction,
-                                          validateAcceptJsonHeaderAction: ValidateAcceptJsonHeaderAction)(implicit ec: ExecutionContext) extends BackendController(cc) with HttpErrorFunctions with ResponseHelper {
+class ArrivalMessagesController @Inject() (
+  cc: ControllerComponents,
+  authAction: AuthAction,
+  messageConnector: ArrivalMessageConnector,
+  validateMessageAction: ValidateArrivalMessageAction,
+  validateAcceptJsonHeaderAction: ValidateAcceptJsonHeaderAction,
+  val metrics: Metrics
+)(implicit ec: ExecutionContext)
+    extends BackendController(cc)
+    with HasActionMetrics
+    with HttpErrorFunctions
+    with ResponseHelper {
 
-  def sendMessageDownstream(arrivalId: String): Action[NodeSeq] = (authAction andThen validateMessageAction).async(parse.xml) {
-    implicit request =>
-      messageConnector.post(request.body.toString, arrivalId).map { response =>
-        response.status match {
-          case s if is2xx(s) =>
-            response.header(LOCATION) match {
-              case Some(locationValue) =>
-                MessageType.getMessageType(request.body) match {
-                  case Some(messageType: MessageType) =>
-                    val messageId = Utils.lastFragment(locationValue)
-                    Accepted(Json.toJson(HateaosArrivalMessagesPostResponseMessage(
-                      arrivalId,
-                      messageId,
-                      messageType.code,
-                      request.body
-                    ))).withHeaders(LOCATION -> routes.ArrivalMessagesController.getArrivalMessage(arrivalId, messageId).urlWithContext)
-                  case None =>
-                    InternalServerError
-                }
-              case _ =>
-                InternalServerError
-            }
-          case _ => handleNon2xx(response)
-        }
+  def sendMessageDownstream(arrivalId: String): Action[NodeSeq] =
+    withMetricsTimerAction("send-arrival-message") {
+      (authAction andThen validateMessageAction).async(parse.xml) {
+        implicit request =>
+          messageConnector.post(request.body.toString, arrivalId).map {
+            response =>
+              response.status match {
+                case s if is2xx(s) =>
+                  response.header(LOCATION) match {
+                    case Some(locationValue) =>
+                      MessageType.getMessageType(request.body) match {
+                        case Some(messageType: MessageType) =>
+                          val messageId = Utils.lastFragment(locationValue)
+                          Accepted(
+                            Json.toJson(
+                              HateaosArrivalMessagesPostResponseMessage(
+                                arrivalId,
+                                messageId,
+                                messageType.code,
+                                request.body
+                              )
+                            )
+                          ).withHeaders(LOCATION -> routes.ArrivalMessagesController.getArrivalMessage(arrivalId, messageId).urlWithContext)
+                        case None =>
+                          InternalServerError
+                      }
+                    case _ =>
+                      InternalServerError
+                  }
+                case _ => handleNon2xx(response)
+              }
+          }
       }
-  }
+    }
 
   def getArrivalMessage(arrivalId: String, messageId: String): Action[AnyContent] =
-    (authAction andThen validateAcceptJsonHeaderAction).async {
-      implicit request => {
-        messageConnector.get(arrivalId, messageId).map {
-          case Right(m) =>
-            Ok(Json.toJson(HateaosArrivalResponseMessage(arrivalId, messageId, m)))
-          case Left(response) =>
-            handleNon2xx(response)
-        }
+    withMetricsTimerAction("get-arrival-message") {
+      (authAction andThen validateAcceptJsonHeaderAction).async {
+        implicit request =>
+          messageConnector.get(arrivalId, messageId).map {
+            case Right(m) =>
+              Ok(Json.toJson(HateaosArrivalResponseMessage(arrivalId, messageId, m)))
+            case Left(response) =>
+              handleNon2xx(response)
+          }
       }
     }
 
   def getArrivalMessages(arrivalId: String): Action[AnyContent] =
-    (authAction andThen validateAcceptJsonHeaderAction).async {
-      implicit request => {
-        messageConnector.getMessages(arrivalId).map {
-          case Right(a) => {
-            Ok(Json.toJson(HateaosResponseArrivalWithMessages(a)))
+    withMetricsTimerAction("get-arrival-messages") {
+      (authAction andThen validateAcceptJsonHeaderAction).async {
+        implicit request =>
+          messageConnector.getMessages(arrivalId).map {
+            case Right(a) =>
+              Ok(Json.toJson(HateaosResponseArrivalWithMessages(a)))
+            case Left(response) =>
+              handleNon2xx(response)
           }
-          case Left(response) =>
-            handleNon2xx(response)
-        }
       }
     }
 }

--- a/app/controllers/ArrivalMessagesController.scala
+++ b/app/controllers/ArrivalMessagesController.scala
@@ -56,6 +56,8 @@ class ArrivalMessagesController @Inject() (
 
   import MetricsKeys.Endpoints._
 
+  lazy val messagesCount = histo(GetArrivalMessagesCount)
+
   def sendMessageDownstream(arrivalId: String): Action[NodeSeq] =
     withMetricsTimerAction(SendArrivalMessage) {
       (authAction andThen validateMessageAction).async(parse.xml) {
@@ -110,6 +112,7 @@ class ArrivalMessagesController @Inject() (
         implicit request =>
           messageConnector.getMessages(arrivalId).map {
             case Right(a) =>
+              messagesCount.update(a.messages.length)
               Ok(Json.toJson(HateaosResponseArrivalWithMessages(a)))
             case Left(response) =>
               handleNon2xx(response)

--- a/app/controllers/ArrivalMessagesController.scala
+++ b/app/controllers/ArrivalMessagesController.scala
@@ -23,7 +23,7 @@ import connectors.ArrivalMessageConnector
 import controllers.actions.AuthAction
 import controllers.actions.ValidateAcceptJsonHeaderAction
 import controllers.actions.ValidateArrivalMessageAction
-import metrics.HasActionMetrics
+import metrics.{HasActionMetrics, MetricsKeys}
 import models.MessageType
 import models.response.HateaosArrivalMessagesPostResponseMessage
 import models.response.HateaosArrivalResponseMessage
@@ -54,8 +54,10 @@ class ArrivalMessagesController @Inject() (
     with HttpErrorFunctions
     with ResponseHelper {
 
+  import MetricsKeys.Endpoints._
+
   def sendMessageDownstream(arrivalId: String): Action[NodeSeq] =
-    withMetricsTimerAction("send-arrival-message") {
+    withMetricsTimerAction(SendArrivalMessage) {
       (authAction andThen validateMessageAction).async(parse.xml) {
         implicit request =>
           messageConnector.post(request.body.toString, arrivalId).map {
@@ -90,7 +92,7 @@ class ArrivalMessagesController @Inject() (
     }
 
   def getArrivalMessage(arrivalId: String, messageId: String): Action[AnyContent] =
-    withMetricsTimerAction("get-arrival-message") {
+    withMetricsTimerAction(GetArrivalMessage) {
       (authAction andThen validateAcceptJsonHeaderAction).async {
         implicit request =>
           messageConnector.get(arrivalId, messageId).map {
@@ -103,7 +105,7 @@ class ArrivalMessagesController @Inject() (
     }
 
   def getArrivalMessages(arrivalId: String): Action[AnyContent] =
-    withMetricsTimerAction("get-arrival-messages") {
+    withMetricsTimerAction(GetArrivalMessages) {
       (authAction andThen validateAcceptJsonHeaderAction).async {
         implicit request =>
           messageConnector.getMessages(arrivalId).map {

--- a/app/controllers/ArrivalMovementController.scala
+++ b/app/controllers/ArrivalMovementController.scala
@@ -23,7 +23,7 @@ import connectors.ArrivalConnector
 import controllers.actions.AuthAction
 import controllers.actions.ValidateAcceptJsonHeaderAction
 import controllers.actions.ValidateArrivalNotificationAction
-import metrics.HasActionMetrics
+import metrics.{HasActionMetrics, MetricsKeys}
 import models.MessageType
 import models.domain.Arrivals
 import models.response.HateaosArrivalMovementPostResponseMessage
@@ -55,8 +55,10 @@ class ArrivalMovementController @Inject() (
     with HttpErrorFunctions
     with ResponseHelper {
 
+  import MetricsKeys.Endpoints._
+
   def createArrivalNotification(): Action[NodeSeq] =
-    withMetricsTimerAction("create-arrival-notification") {
+    withMetricsTimerAction(CreateArrivalNotification) {
       (authAction andThen validateArrivalNotificationAction).async(parse.xml) {
         implicit request =>
           arrivalConnector.post(request.body.toString).map {
@@ -90,7 +92,7 @@ class ArrivalMovementController @Inject() (
     }
 
   def resubmitArrivalNotification(arrivalId: String): Action[NodeSeq] =
-    withMetricsTimerAction("resubmit-arrival-notification") {
+    withMetricsTimerAction(ResubmitArrivalNotification) {
       (authAction andThen validateArrivalNotificationAction).async(parse.xml) {
         implicit request =>
           arrivalConnector.put(request.body.toString, arrivalId).map {
@@ -125,7 +127,7 @@ class ArrivalMovementController @Inject() (
     }
 
   def getArrival(arrivalId: String): Action[AnyContent] =
-    withMetricsTimerAction("get-arrival") {
+    withMetricsTimerAction(GetArrival) {
       (authAction andThen validateAcceptJsonHeaderAction).async {
         implicit request =>
           arrivalConnector.get(arrivalId).map {
@@ -138,7 +140,7 @@ class ArrivalMovementController @Inject() (
     }
 
   def getArrivalsForEori: Action[AnyContent] =
-    withMetricsTimerAction("get-arrivals-for-eori") {
+    withMetricsTimerAction(GetArrivalsForEori) {
       (authAction andThen validateAcceptJsonHeaderAction).async {
         implicit request =>
           arrivalConnector.getForEori.map {

--- a/app/controllers/ArrivalMovementController.scala
+++ b/app/controllers/ArrivalMovementController.scala
@@ -16,103 +16,137 @@
 
 package controllers
 
+import javax.inject.Inject
+
+import com.kenshoo.play.metrics.Metrics
 import connectors.ArrivalConnector
-import controllers.actions.{AuthAction, ValidateAcceptJsonHeaderAction, ValidateArrivalNotificationAction}
+import controllers.actions.AuthAction
+import controllers.actions.ValidateAcceptJsonHeaderAction
+import controllers.actions.ValidateArrivalNotificationAction
+import metrics.HasActionMetrics
 import models.MessageType
 import models.domain.Arrivals
-
-import javax.inject.Inject
-import models.response.{HateaosArrivalMovementPostResponseMessage, HateaosResponseArrival, HateaosResponseArrivals}
+import models.response.HateaosArrivalMovementPostResponseMessage
+import models.response.HateaosResponseArrival
+import models.response.HateaosResponseArrivals
 import play.api.libs.json.Json
-import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.ControllerComponents
 import uk.gov.hmrc.http.HttpErrorFunctions
-import uk.gov.hmrc.play.bootstrap.controller.BackendController
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import utils.CallOps._
-import utils.{ResponseHelper, Utils}
+import utils.ResponseHelper
+import utils.Utils
 
 import scala.concurrent.ExecutionContext
 import scala.xml.NodeSeq
 
-class ArrivalMovementController @Inject()(cc: ControllerComponents,
-                                   authAction: AuthAction,
-                                   arrivalConnector: ArrivalConnector,
-                                   validateArrivalNotificationAction: ValidateArrivalNotificationAction,
-                                   validateAcceptJsonHeaderAction: ValidateAcceptJsonHeaderAction)(implicit ec: ExecutionContext) extends BackendController(cc) with HttpErrorFunctions with ResponseHelper {
+class ArrivalMovementController @Inject() (
+  cc: ControllerComponents,
+  authAction: AuthAction,
+  arrivalConnector: ArrivalConnector,
+  validateArrivalNotificationAction: ValidateArrivalNotificationAction,
+  validateAcceptJsonHeaderAction: ValidateAcceptJsonHeaderAction,
+  val metrics: Metrics
+)(implicit ec: ExecutionContext)
+    extends BackendController(cc)
+    with HasActionMetrics
+    with HttpErrorFunctions
+    with ResponseHelper {
 
-  def createArrivalNotification(): Action[NodeSeq] = (authAction andThen validateArrivalNotificationAction).async(parse.xml) {
-    implicit request =>
-      arrivalConnector.post(request.body.toString).map { response =>
-        response.status match {
-          case status if is2xx(status) =>
-            response.header(LOCATION) match {
-              case Some(locationValue: String) =>
-                MessageType.getMessageType(request.body) match {
-                  case Some(messageType: MessageType) =>
-                    val arrivalId = Utils.lastFragment(locationValue)
-                    Accepted(Json.toJson(HateaosArrivalMovementPostResponseMessage(
-                      arrivalId,
-                      messageType.code,
-                      request.body
-                    ))).withHeaders(LOCATION -> routes.ArrivalMovementController.getArrival(arrivalId).urlWithContext)
-                  case None =>
-                    InternalServerError
-                }
-              case _ =>
-                InternalServerError
-            }
-          case _ => handleNon2xx(response)
-        }
+  def createArrivalNotification(): Action[NodeSeq] =
+    withMetricsTimerAction("create-arrival-notification") {
+      (authAction andThen validateArrivalNotificationAction).async(parse.xml) {
+        implicit request =>
+          arrivalConnector.post(request.body.toString).map {
+            response =>
+              response.status match {
+                case status if is2xx(status) =>
+                  response.header(LOCATION) match {
+                    case Some(locationValue: String) =>
+                      MessageType.getMessageType(request.body) match {
+                        case Some(messageType: MessageType) =>
+                          val arrivalId = Utils.lastFragment(locationValue)
+                          Accepted(
+                            Json.toJson(
+                              HateaosArrivalMovementPostResponseMessage(
+                                arrivalId,
+                                messageType.code,
+                                request.body
+                              )
+                            )
+                          ).withHeaders(LOCATION -> routes.ArrivalMovementController.getArrival(arrivalId).urlWithContext)
+                        case None =>
+                          InternalServerError
+                      }
+                    case _ =>
+                      InternalServerError
+                  }
+                case _ => handleNon2xx(response)
+              }
+          }
       }
-  }
+    }
 
-  def resubmitArrivalNotification(arrivalId: String): Action[NodeSeq] = (authAction andThen validateArrivalNotificationAction).async(parse.xml) {
-    implicit request =>
-      arrivalConnector.put(request.body.toString, arrivalId).map { response =>
-        response.status match {
-          case status if is2xx(status) =>
-            response.header(LOCATION) match {
-              case Some(locationValue: String) =>
-                MessageType.getMessageType(request.body) match {
-                  case Some(messageType: MessageType) =>
-                    val arrivalId = Utils.lastFragment(locationValue)
-                    Accepted(Json.toJson(HateaosArrivalMovementPostResponseMessage(
-                      arrivalId,
-                      messageType.code,
-                      request.body
-                    ))).withHeaders(LOCATION -> routes.ArrivalMovementController.getArrival(arrivalId).urlWithContext)
-                  case None =>
-                    InternalServerError
-                }
-              case _ =>
-                InternalServerError
-            }
-          case _ =>
-            handleNon2xx(response)
-        }
+  def resubmitArrivalNotification(arrivalId: String): Action[NodeSeq] =
+    withMetricsTimerAction("resubmit-arrival-notification") {
+      (authAction andThen validateArrivalNotificationAction).async(parse.xml) {
+        implicit request =>
+          arrivalConnector.put(request.body.toString, arrivalId).map {
+            response =>
+              response.status match {
+                case status if is2xx(status) =>
+                  response.header(LOCATION) match {
+                    case Some(locationValue: String) =>
+                      MessageType.getMessageType(request.body) match {
+                        case Some(messageType: MessageType) =>
+                          val arrivalId = Utils.lastFragment(locationValue)
+                          Accepted(
+                            Json.toJson(
+                              HateaosArrivalMovementPostResponseMessage(
+                                arrivalId,
+                                messageType.code,
+                                request.body
+                              )
+                            )
+                          ).withHeaders(LOCATION -> routes.ArrivalMovementController.getArrival(arrivalId).urlWithContext)
+                        case None =>
+                          InternalServerError
+                      }
+                    case _ =>
+                      InternalServerError
+                  }
+                case _ =>
+                  handleNon2xx(response)
+              }
+          }
       }
-  }
+    }
 
   def getArrival(arrivalId: String): Action[AnyContent] =
-    (authAction andThen validateAcceptJsonHeaderAction).async {
-      implicit request => {
-        arrivalConnector.get(arrivalId).map {
-          case Right(arrival) =>
-            Ok(Json.toJson(HateaosResponseArrival(arrival)))
-          case Left(invalidResponse) =>
-            handleNon2xx(invalidResponse)
-        }
+    withMetricsTimerAction("get-arrival") {
+      (authAction andThen validateAcceptJsonHeaderAction).async {
+        implicit request =>
+          arrivalConnector.get(arrivalId).map {
+            case Right(arrival) =>
+              Ok(Json.toJson(HateaosResponseArrival(arrival)))
+            case Left(invalidResponse) =>
+              handleNon2xx(invalidResponse)
+          }
       }
     }
 
   def getArrivalsForEori: Action[AnyContent] =
-    (authAction andThen validateAcceptJsonHeaderAction).async {
-      implicit request => {
-        arrivalConnector.getForEori.map {
-          case Right(arrivals: Arrivals) =>
-            Ok(Json.toJson(HateaosResponseArrivals(arrivals)))
-          case Left(invalidResponse) =>
-            handleNon2xx(invalidResponse)
-        }
+    withMetricsTimerAction("get-arrivals-for-eori") {
+      (authAction andThen validateAcceptJsonHeaderAction).async {
+        implicit request =>
+          arrivalConnector.getForEori.map {
+            case Right(arrivals: Arrivals) =>
+              Ok(Json.toJson(HateaosResponseArrivals(arrivals)))
+            case Left(invalidResponse) =>
+              handleNon2xx(invalidResponse)
+          }
       }
     }
 }

--- a/app/controllers/ArrivalMovementController.scala
+++ b/app/controllers/ArrivalMovementController.scala
@@ -57,6 +57,8 @@ class ArrivalMovementController @Inject() (
 
   import MetricsKeys.Endpoints._
 
+  lazy val arrivalsCount = histo(GetArrivalsForEoriCount)
+
   def createArrivalNotification(): Action[NodeSeq] =
     withMetricsTimerAction(CreateArrivalNotification) {
       (authAction andThen validateArrivalNotificationAction).async(parse.xml) {
@@ -145,6 +147,7 @@ class ArrivalMovementController @Inject() (
         implicit request =>
           arrivalConnector.getForEori.map {
             case Right(arrivals: Arrivals) =>
+              arrivalsCount.update(arrivals.arrivals.length)
               Ok(Json.toJson(HateaosResponseArrivals(arrivals)))
             case Left(invalidResponse) =>
               handleNon2xx(invalidResponse)

--- a/app/controllers/DepartureMessagesController.scala
+++ b/app/controllers/DepartureMessagesController.scala
@@ -56,6 +56,8 @@ class DepartureMessagesController @Inject() (
 
   import MetricsKeys.Endpoints._
 
+  lazy val messagesCount = histo(GetDepartureMessagesCount)
+
   def sendMessageDownstream(departureId: String): Action[NodeSeq] =
     withMetricsTimerAction(SendDepartureMessage) {
       (authAction andThen validateMessageAction).async(parse.xml) {
@@ -97,6 +99,7 @@ class DepartureMessagesController @Inject() (
         implicit request =>
           messageConnector.getMessages(departureId).map {
             case Right(d) =>
+              messagesCount.update(d.messages.length)
               Ok(Json.toJson(HateaosResponseDepartureWithMessages(d)))
             case Left(response) =>
               handleNon2xx(response)

--- a/app/controllers/DepartureMessagesController.scala
+++ b/app/controllers/DepartureMessagesController.scala
@@ -16,77 +16,102 @@
 
 package controllers
 
-import connectors.DepartureMessageConnector
-import controllers.actions.{AuthAction, ValidateAcceptJsonHeaderAction, ValidateDepartureMessageAction}
-import models.MessageType
-
 import javax.inject.Inject
-import models.response.{HateaosDepartureMessagesPostResponseMessage, HateaosDepartureResponseMessage, HateaosResponseDepartureWithMessages}
+
+import com.kenshoo.play.metrics.Metrics
+import connectors.DepartureMessageConnector
+import controllers.actions.AuthAction
+import controllers.actions.ValidateAcceptJsonHeaderAction
+import controllers.actions.ValidateDepartureMessageAction
+import metrics.HasActionMetrics
+import models.MessageType
+import models.response.HateaosDepartureMessagesPostResponseMessage
+import models.response.HateaosDepartureResponseMessage
+import models.response.HateaosResponseDepartureWithMessages
 import play.api.libs.json.Json
-import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.ControllerComponents
 import uk.gov.hmrc.http.HttpErrorFunctions
-import uk.gov.hmrc.play.bootstrap.controller.BackendController
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import utils.CallOps._
-import utils.{ResponseHelper, Utils}
+import utils.ResponseHelper
+import utils.Utils
 
 import scala.concurrent.ExecutionContext
 import scala.xml.NodeSeq
 
-class DepartureMessagesController @Inject()(cc: ControllerComponents,
-                                            authAction: AuthAction,
-                                            messageConnector: DepartureMessageConnector,
-                                            validateMessageAction: ValidateDepartureMessageAction,
-                                            validateAcceptJsonHeaderAction: ValidateAcceptJsonHeaderAction)(implicit ec: ExecutionContext) extends BackendController(cc) with HttpErrorFunctions with ResponseHelper {
+class DepartureMessagesController @Inject() (
+  cc: ControllerComponents,
+  authAction: AuthAction,
+  messageConnector: DepartureMessageConnector,
+  validateMessageAction: ValidateDepartureMessageAction,
+  validateAcceptJsonHeaderAction: ValidateAcceptJsonHeaderAction,
+  val metrics: Metrics
+)(implicit ec: ExecutionContext)
+    extends BackendController(cc)
+    with HasActionMetrics
+    with HttpErrorFunctions
+    with ResponseHelper {
 
-  def sendMessageDownstream(departureId: String): Action[NodeSeq] = (authAction andThen validateMessageAction).async(parse.xml) {
-    implicit request =>
-      messageConnector.post(request.body.toString, departureId).map { response =>
-        response.status match {
-          case s if is2xx(s) =>
-            response.header(LOCATION) match {
-              case Some(locationValue) =>
-                MessageType.getMessageType(request.body) match {
-                  case Some(messageType: MessageType) =>
-                    val messageId = Utils.lastFragment(locationValue)
-                    Accepted(Json.toJson(HateaosDepartureMessagesPostResponseMessage(
-                      departureId,
-                      messageId,
-                      messageType.code,
-                      request.body
-                    ))).withHeaders(LOCATION -> routes.DepartureMessagesController.getDepartureMessage(departureId, messageId).urlWithContext)
-                  case None =>
-                    InternalServerError
-                }
-              case _ =>
-                InternalServerError
-            }
-          case _ => handleNon2xx(response)
-        }
+  def sendMessageDownstream(departureId: String): Action[NodeSeq] =
+    withMetricsTimerAction("send-departure-message") {
+      (authAction andThen validateMessageAction).async(parse.xml) {
+        implicit request =>
+          messageConnector.post(request.body.toString, departureId).map {
+            response =>
+              response.status match {
+                case s if is2xx(s) =>
+                  response.header(LOCATION) match {
+                    case Some(locationValue) =>
+                      MessageType.getMessageType(request.body) match {
+                        case Some(messageType: MessageType) =>
+                          val messageId = Utils.lastFragment(locationValue)
+                          Accepted(
+                            Json.toJson(
+                              HateaosDepartureMessagesPostResponseMessage(
+                                departureId,
+                                messageId,
+                                messageType.code,
+                                request.body
+                              )
+                            )
+                          ).withHeaders(LOCATION -> routes.DepartureMessagesController.getDepartureMessage(departureId, messageId).urlWithContext)
+                        case None =>
+                          InternalServerError
+                      }
+                    case _ =>
+                      InternalServerError
+                  }
+                case _ => handleNon2xx(response)
+              }
+          }
       }
-  }
+    }
 
   def getDepartureMessages(departureId: String): Action[AnyContent] =
-    (authAction andThen validateAcceptJsonHeaderAction).async {
-      implicit request => {
-        messageConnector.getMessages(departureId).map {
-          case Right(d) => {
-            Ok(Json.toJson(HateaosResponseDepartureWithMessages(d)))
+    withMetricsTimerAction("get-departure-messages") {
+      (authAction andThen validateAcceptJsonHeaderAction).async {
+        implicit request =>
+          messageConnector.getMessages(departureId).map {
+            case Right(d) =>
+              Ok(Json.toJson(HateaosResponseDepartureWithMessages(d)))
+            case Left(response) =>
+              handleNon2xx(response)
           }
-          case Left(response) =>
-            handleNon2xx(response)
-        }
       }
     }
 
   def getDepartureMessage(departureId: String, messageId: String): Action[AnyContent] =
-    (authAction andThen validateAcceptJsonHeaderAction).async {
-      implicit request => {
-        messageConnector.get(departureId, messageId).map {
-          case Right(m) =>
-            Ok(Json.toJson(HateaosDepartureResponseMessage(departureId, messageId, m)))
-          case Left(response) =>
-            handleNon2xx(response)
-        }
+    withMetricsTimerAction("get-departure-message") {
+      (authAction andThen validateAcceptJsonHeaderAction).async {
+        implicit request =>
+          messageConnector.get(departureId, messageId).map {
+            case Right(m) =>
+              Ok(Json.toJson(HateaosDepartureResponseMessage(departureId, messageId, m)))
+            case Left(response) =>
+              handleNon2xx(response)
+          }
       }
     }
 }

--- a/app/controllers/DepartureMessagesController.scala
+++ b/app/controllers/DepartureMessagesController.scala
@@ -23,7 +23,7 @@ import connectors.DepartureMessageConnector
 import controllers.actions.AuthAction
 import controllers.actions.ValidateAcceptJsonHeaderAction
 import controllers.actions.ValidateDepartureMessageAction
-import metrics.HasActionMetrics
+import metrics.{HasActionMetrics, MetricsKeys}
 import models.MessageType
 import models.response.HateaosDepartureMessagesPostResponseMessage
 import models.response.HateaosDepartureResponseMessage
@@ -54,8 +54,10 @@ class DepartureMessagesController @Inject() (
     with HttpErrorFunctions
     with ResponseHelper {
 
+  import MetricsKeys.Endpoints._
+
   def sendMessageDownstream(departureId: String): Action[NodeSeq] =
-    withMetricsTimerAction("send-departure-message") {
+    withMetricsTimerAction(SendDepartureMessage) {
       (authAction andThen validateMessageAction).async(parse.xml) {
         implicit request =>
           messageConnector.post(request.body.toString, departureId).map {
@@ -90,7 +92,7 @@ class DepartureMessagesController @Inject() (
     }
 
   def getDepartureMessages(departureId: String): Action[AnyContent] =
-    withMetricsTimerAction("get-departure-messages") {
+    withMetricsTimerAction(GetDepartureMessages) {
       (authAction andThen validateAcceptJsonHeaderAction).async {
         implicit request =>
           messageConnector.getMessages(departureId).map {
@@ -103,7 +105,7 @@ class DepartureMessagesController @Inject() (
     }
 
   def getDepartureMessage(departureId: String, messageId: String): Action[AnyContent] =
-    withMetricsTimerAction("get-departure-message") {
+    withMetricsTimerAction(GetDepartureMessage) {
       (authAction andThen validateAcceptJsonHeaderAction).async {
         implicit request =>
           messageConnector.get(departureId, messageId).map {

--- a/app/controllers/DeparturesController.scala
+++ b/app/controllers/DeparturesController.scala
@@ -61,6 +61,8 @@ class DeparturesController @Inject() (
 
   import MetricsKeys.Endpoints._
 
+  lazy val departuresCount = histo(GetDeparturesForEoriCount)
+
   def submitDeclaration(): Action[NodeSeq] =
     withMetricsTimerAction(SubmitDepartureDeclaration) {
       (authAction andThen validateDepartureDeclarationAction andThen ensureGuaranteeAction).async(parse.xml) {
@@ -117,6 +119,7 @@ class DeparturesController @Inject() (
         implicit request =>
           departuresConnector.getForEori.map {
             case Right(departures) =>
+              departuresCount.update(departures.departures.length)
               Ok(Json.toJson(HateaosResponseDepartures(departures)))
             case Left(invalidResponse) =>
               handleNon2xx(invalidResponse)

--- a/app/controllers/DeparturesController.scala
+++ b/app/controllers/DeparturesController.scala
@@ -26,7 +26,7 @@ import controllers.actions.AuthAction
 import controllers.actions.EnsureGuaranteeAction
 import controllers.actions.ValidateAcceptJsonHeaderAction
 import controllers.actions.ValidateDepartureDeclarationAction
-import metrics.HasActionMetrics
+import metrics.{HasActionMetrics, MetricsKeys}
 import models.MessageType
 import models.response.HateaosDeparturePostResponseMessage
 import models.response.HateaosResponseDeparture
@@ -59,8 +59,10 @@ class DeparturesController @Inject() (
     with HttpErrorFunctions
     with ResponseHelper {
 
+  import MetricsKeys.Endpoints._
+
   def submitDeclaration(): Action[NodeSeq] =
-    withMetricsTimerAction("submit-departure-declaration") {
+    withMetricsTimerAction(SubmitDepartureDeclaration) {
       (authAction andThen validateDepartureDeclarationAction andThen ensureGuaranteeAction).async(parse.xml) {
         implicit request =>
           departuresConnector.post(request.newXml.toString).map {
@@ -97,7 +99,7 @@ class DeparturesController @Inject() (
     }
 
   def getDeparture(departureId: String): Action[AnyContent] =
-    withMetricsTimerAction("get-departure") {
+    withMetricsTimerAction(GetDeparture) {
       (authAction andThen validateAcceptJsonHeaderAction).async {
         implicit request =>
           departuresConnector.get(departureId).map {
@@ -110,7 +112,7 @@ class DeparturesController @Inject() (
     }
 
   def getDeparturesForEori: Action[AnyContent] =
-    withMetricsTimerAction("get-departures-for-eori") {
+    withMetricsTimerAction(GetDeparturesForEori) {
       (authAction andThen validateAcceptJsonHeaderAction).async {
         implicit request =>
           departuresConnector.getForEori.map {

--- a/app/controllers/DeparturesController.scala
+++ b/app/controllers/DeparturesController.scala
@@ -16,81 +16,109 @@
 
 package controllers
 
-import audit.{AuditService, AuditType}
-import connectors.DeparturesConnector
-import controllers.actions.{AuthAction, EnsureGuaranteeAction, ValidateAcceptJsonHeaderAction, ValidateDepartureDeclarationAction}
-import models.MessageType
-
 import javax.inject.Inject
-import models.response.{HateaosDeparturePostResponseMessage, HateaosResponseDeparture, HateaosResponseDepartures}
+
+import audit.AuditService
+import audit.AuditType
+import com.kenshoo.play.metrics.Metrics
+import connectors.DeparturesConnector
+import controllers.actions.AuthAction
+import controllers.actions.EnsureGuaranteeAction
+import controllers.actions.ValidateAcceptJsonHeaderAction
+import controllers.actions.ValidateDepartureDeclarationAction
+import metrics.HasActionMetrics
+import models.MessageType
+import models.response.HateaosDeparturePostResponseMessage
+import models.response.HateaosResponseDeparture
+import models.response.HateaosResponseDepartures
 import play.api.libs.json.Json
-import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.ControllerComponents
 import uk.gov.hmrc.http.HttpErrorFunctions
-import uk.gov.hmrc.play.bootstrap.controller.BackendController
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import utils.CallOps._
-import utils.{ResponseHelper, Utils}
+import utils.ResponseHelper
+import utils.Utils
 
 import scala.concurrent.ExecutionContext
 import scala.xml.NodeSeq
 
-class DeparturesController @Inject()(cc: ControllerComponents,
-                                     authAction: AuthAction,
-                                     departuresConnector: DeparturesConnector,
-                                     validateAcceptJsonHeaderAction: ValidateAcceptJsonHeaderAction,
-                                     validateDepartureDeclarationAction: ValidateDepartureDeclarationAction,
-                                     ensureGuaranteeAction: EnsureGuaranteeAction,
-                                     auditService: AuditService)(implicit ec: ExecutionContext) extends BackendController(cc) with HttpErrorFunctions with ResponseHelper {
+class DeparturesController @Inject() (
+  cc: ControllerComponents,
+  authAction: AuthAction,
+  departuresConnector: DeparturesConnector,
+  validateAcceptJsonHeaderAction: ValidateAcceptJsonHeaderAction,
+  validateDepartureDeclarationAction: ValidateDepartureDeclarationAction,
+  ensureGuaranteeAction: EnsureGuaranteeAction,
+  auditService: AuditService,
+  val metrics: Metrics
+)(implicit ec: ExecutionContext)
+    extends BackendController(cc)
+    with HasActionMetrics
+    with HttpErrorFunctions
+    with ResponseHelper {
 
-  def submitDeclaration(): Action[NodeSeq] = (authAction andThen validateDepartureDeclarationAction andThen ensureGuaranteeAction).async(parse.xml) {
-    implicit request => {
-      departuresConnector.post(request.newXml.toString).map { response =>
-        response.status match {
-          case status if is2xx(status) =>
-            response.header(LOCATION) match {
-              case Some(locationValue) =>
-                if (request.guaranteeAdded) {
-                  auditService.auditEvent(AuditType.TenThousandEuroGuaranteeAdded, request.newXml)
-                }
-                MessageType.getMessageType(request.body) match {
-                  case Some(messageType: MessageType) =>
-                    val departureId = Utils.lastFragment(locationValue)
-                    Accepted(Json.toJson(HateaosDeparturePostResponseMessage(
-                      departureId,
-                      messageType.code,
-                      request.body
-                    ))).withHeaders(LOCATION -> routes.DeparturesController.getDeparture(departureId).urlWithContext)
-                  case None =>
-                    InternalServerError
-                }
-              case _ =>
-                InternalServerError
-            }
-          case _ => handleNon2xx(response)
-        }
+  def submitDeclaration(): Action[NodeSeq] =
+    withMetricsTimerAction("submit-departure-declaration") {
+      (authAction andThen validateDepartureDeclarationAction andThen ensureGuaranteeAction).async(parse.xml) {
+        implicit request =>
+          departuresConnector.post(request.newXml.toString).map {
+            response =>
+              response.status match {
+                case status if is2xx(status) =>
+                  response.header(LOCATION) match {
+                    case Some(locationValue) =>
+                      if (request.guaranteeAdded) {
+                        auditService.auditEvent(AuditType.TenThousandEuroGuaranteeAdded, request.newXml)
+                      }
+                      MessageType.getMessageType(request.body) match {
+                        case Some(messageType: MessageType) =>
+                          val departureId = Utils.lastFragment(locationValue)
+                          Accepted(
+                            Json.toJson(
+                              HateaosDeparturePostResponseMessage(
+                                departureId,
+                                messageType.code,
+                                request.body
+                              )
+                            )
+                          ).withHeaders(LOCATION -> routes.DeparturesController.getDeparture(departureId).urlWithContext)
+                        case None =>
+                          InternalServerError
+                      }
+                    case _ =>
+                      InternalServerError
+                  }
+                case _ => handleNon2xx(response)
+              }
+          }
       }
     }
-  }
 
-  def getDeparture(departureId: String): Action[AnyContent] = (authAction andThen validateAcceptJsonHeaderAction).async {
-    implicit request => {
-      departuresConnector.get(departureId).map {
-        case Right(departure) =>
-          Ok(Json.toJson(HateaosResponseDeparture(departure)))
-        case Left(invalidResponse) =>
-          handleNon2xx(invalidResponse)
+  def getDeparture(departureId: String): Action[AnyContent] =
+    withMetricsTimerAction("get-departure") {
+      (authAction andThen validateAcceptJsonHeaderAction).async {
+        implicit request =>
+          departuresConnector.get(departureId).map {
+            case Right(departure) =>
+              Ok(Json.toJson(HateaosResponseDeparture(departure)))
+            case Left(invalidResponse) =>
+              handleNon2xx(invalidResponse)
+          }
       }
     }
-  }
 
   def getDeparturesForEori: Action[AnyContent] =
-    (authAction andThen validateAcceptJsonHeaderAction).async {
-      implicit request => {
-        departuresConnector.getForEori.map {
-          case Right(departures) =>
-            Ok(Json.toJson(HateaosResponseDepartures(departures)))
-          case Left(invalidResponse) =>
-            handleNon2xx(invalidResponse)
-        }
+    withMetricsTimerAction("get-departures-for-eori") {
+      (authAction andThen validateAcceptJsonHeaderAction).async {
+        implicit request =>
+          departuresConnector.getForEori.map {
+            case Right(departures) =>
+              Ok(Json.toJson(HateaosResponseDepartures(departures)))
+            case Left(invalidResponse) =>
+              handleNon2xx(invalidResponse)
+          }
       }
     }
 }

--- a/app/metrics/HasMetrics.scala
+++ b/app/metrics/HasMetrics.scala
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package metrics
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import com.codahale.metrics.MetricRegistry
+import com.codahale.metrics.Timer
+import com.kenshoo.play.metrics.Metrics
+import play.api.mvc.Action
+import play.api.mvc.BaseController
+import play.api.mvc.Result
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+import uk.gov.hmrc.http.HttpResponse
+
+trait HasActionMetrics extends HasMetrics {
+  self: BaseController =>
+
+  /** Execute a [[play.api.mvc.Action]] with a metrics timer.
+    * Intended for use in controllers that return HTTP responses.
+    *
+    * @param metric The id of the metric to be collected
+    * @param action The action to wrap with metrics collection
+    * @param ec The [[scala.concurrent.ExecutionContext]] on which the block of code should run
+    * @return an action which captures metrics about the wrapped action
+    */
+  def withMetricsTimerAction[A](metric: Metric)(action: Action[A])(implicit ec: ExecutionContext): Action[A] =
+    Action(action.parser).async {
+      request =>
+        withMetricsTimerResult(metric)(action(request))
+    }
+}
+
+trait HasMetrics {
+  type Metric = String
+
+  def metrics: Metrics
+
+  lazy val registry: MetricRegistry = metrics.defaultRegistry
+
+  val localMetrics = new LocalMetrics
+
+  class LocalMetrics {
+    def startTimer(metric: Metric)                    = registry.timer(s"$metric-timer").time()
+    def stopTimer(context: Timer.Context)             = context.stop()
+    def incrementSuccessCounter(metric: Metric): Unit = registry.counter(s"$metric-success-counter").inc()
+    def incrementFailedCounter(metric: Metric): Unit  = registry.counter(s"$metric-failed-counter").inc()
+  }
+
+  class MetricsTimer(metric: Metric) {
+    val timer        = localMetrics.startTimer(metric)
+    val timerRunning = new AtomicBoolean(true)
+
+    def completeWithSuccess(): Unit =
+      if (timerRunning.compareAndSet(true, false)) {
+        localMetrics.stopTimer(timer)
+        localMetrics.incrementSuccessCounter(metric)
+      }
+
+    def completeWithFailure(): Unit =
+      if (timerRunning.compareAndSet(true, false)) {
+        localMetrics.stopTimer(timer)
+        localMetrics.incrementFailedCounter(metric)
+      }
+  }
+
+  /** Execute a block of code with a metrics timer.
+    * Intended for use in controllers that return HTTP responses.
+    *
+    * @param metric The id of the metric to be collected
+    * @param block The block of code to execute asynchronously
+    * @param ec The [[scala.concurrent.ExecutionContext]] on which the block of code should run
+    * @return The result of the block of code
+    */
+  def withMetricsTimerResponse(metric: Metric)(block: => Future[HttpResponse])(implicit ec: ExecutionContext): Future[HttpResponse] =
+    withMetricsTimer(metric) {
+      timer =>
+        try {
+          val response = block
+
+          // Clean up timer according to server response
+          response.foreach {
+            response =>
+              if (isFailureStatus(response.status))
+                timer.completeWithFailure()
+              else
+                timer.completeWithSuccess()
+          }
+
+          // Clean up timer for unhandled exceptions
+          response.failed.foreach(
+            _ => timer.completeWithFailure()
+          )
+
+          response
+
+        } catch {
+          case NonFatal(e) =>
+            timer.completeWithFailure()
+            throw e
+        }
+    }
+
+  /** Execute a block of code with a metrics timer.
+    * Intended for use in controllers that return HTTP responses.
+    *
+    * @param metric The id of the metric to be collected
+    * @param block The block of code to execute asynchronously
+    * @param ec The [[scala.concurrent.ExecutionContext]] on which the block of code should run
+    * @return The result of the block of code
+    */
+  def withMetricsTimerResult(metric: Metric)(block: => Future[Result])(implicit ec: ExecutionContext): Future[Result] =
+    withMetricsTimer(metric) {
+      timer =>
+        try {
+          val result = block
+
+          // Clean up timer according to server response
+          result.foreach {
+            result =>
+              if (isFailureStatus(result.header.status))
+                timer.completeWithFailure()
+              else
+                timer.completeWithSuccess()
+          }
+
+          // Clean up timer for unhandled exceptions
+          result.failed.foreach(
+            _ => timer.completeWithFailure()
+          )
+
+          result
+
+        } catch {
+          case NonFatal(e) =>
+            timer.completeWithFailure()
+            throw e
+        }
+    }
+
+  /** Execute a block of code with a metrics timer.
+    *
+    * Intended for use in connectors that call other microservices.
+    *
+    * It's expected that the user of this method might want to handle
+    * connector failures gracefully and therefore they are given a [[MetricsTimer]]
+    * to optionally record whether the call was a success or a failure.
+    *
+    * If the user does not specify otherwise the status of the result Future is
+    * used to determine whether the block was successful or not.
+    *
+    * @param metric The id of the metric to be collected
+    * @param block The block of code to execute asynchronously
+    * @param ec The [[scala.concurrent.ExecutionContext]] on which the block of code should run
+    * @return The result of the block of code
+    */
+  def withMetricsTimerAsync[T](
+    metric: Metric
+  )(block: MetricsTimer => Future[T])(implicit ec: ExecutionContext): Future[T] =
+    withMetricsTimer(metric) {
+      timer =>
+        try {
+          val result = block(timer)
+
+          // Clean up timer if the user doesn't
+          result.foreach(
+            _ => timer.completeWithSuccess()
+          )
+
+          // Clean up timer on unhandled exceptions
+          result.failed.foreach(
+            _ => timer.completeWithFailure()
+          )
+
+          result
+
+        } catch {
+          case NonFatal(e) =>
+            timer.completeWithFailure()
+            throw e
+        }
+    }
+
+  private def withMetricsTimer[T](metric: Metric)(block: MetricsTimer => T): T =
+    block(new MetricsTimer(metric))
+
+  private def isFailureStatus(status: Int) =
+    status / 100 >= 4
+}

--- a/app/metrics/MetricsKeys.scala
+++ b/app/metrics/MetricsKeys.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package metrics
+
+object MetricsKeys {
+  object ArrivalBackend {
+    val Post = "arrival-backend-post"
+    val Put = "arrival-backend-put"
+    val GetById = "arrival-backend-get-by-id"
+    val GetForEori = "arrival-backend-get-for-eori"
+    val PostMessage = "arrival-backend-post-message"
+    val GetMessageById = "arrival-backend-get-message-by-id"
+    val GetMessagesForArrival = "arrival-backend-get-messages-for-arrival"
+  }
+
+  object DeparturesBackend {
+    val Post = "departures-backend-post"
+    val GetById = "departures-backend-get-by-id"
+    val GetForEori = "departures-backend-get-for-eori"
+    val PostMessage = "departures-backend-post-message"
+    val GetMessageById = "departures-backend-get-message-by-id"
+    val GetMessagesForDeparture = "departures-backend-get-messages-for-departure"
+  }
+
+  object Endpoints {
+    // Arrivals
+    val GetArrival = "get-arrival"
+    val GetArrivalsForEori = "get-arrivals-for-eori"
+    val GetArrivalMessage ="get-arrival-message"
+    val GetArrivalMessages = "get-arrival-messages"
+    val SendArrivalMessage = "send-arrival-message"
+    val CreateArrivalNotification = "create-arrival-notification"
+    val ResubmitArrivalNotification = "resubmit-arrival-notification"
+    // Departures
+    val GetDeparture = "get-departure"
+    val GetDeparturesForEori = "get-departures-for-eori"
+    val GetDepartureMessage = "get-departure-message"
+    val GetDepartureMessages = "get-departure-messages"
+    val SendDepartureMessage = "send-departure-message"
+    val SubmitDepartureDeclaration = "submit-departure-declaration"
+  }
+}

--- a/app/metrics/MetricsKeys.scala
+++ b/app/metrics/MetricsKeys.scala
@@ -37,19 +37,24 @@ object MetricsKeys {
   }
 
   object Endpoints {
+    def count(metricKey: String) = s"$metricKey-count"
     // Arrivals
     val GetArrival = "get-arrival"
     val GetArrivalsForEori = "get-arrivals-for-eori"
+    val GetArrivalsForEoriCount = count(GetArrivalsForEori)
     val GetArrivalMessage ="get-arrival-message"
     val GetArrivalMessages = "get-arrival-messages"
+    val GetArrivalMessagesCount = count(GetArrivalMessages)
     val SendArrivalMessage = "send-arrival-message"
     val CreateArrivalNotification = "create-arrival-notification"
     val ResubmitArrivalNotification = "resubmit-arrival-notification"
     // Departures
     val GetDeparture = "get-departure"
     val GetDeparturesForEori = "get-departures-for-eori"
+    val GetDeparturesForEoriCount = count(GetDeparturesForEori)
     val GetDepartureMessage = "get-departure-message"
     val GetDepartureMessages = "get-departure-messages"
+    val GetDepartureMessagesCount = count(GetDepartureMessages)
     val SendDepartureMessage = "send-departure-message"
     val SubmitDepartureDeclaration = "submit-departure-declaration"
   }

--- a/it/connectors/WiremockSuite.scala
+++ b/it/connectors/WiremockSuite.scala
@@ -2,10 +2,12 @@ package connectors
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+import com.kenshoo.play.metrics.Metrics
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
 import play.api.Application
-import play.api.inject.Injector
+import play.api.inject.{bind, Injector}
 import play.api.inject.guice.{GuiceApplicationBuilder, GuiceableModule}
+import utils.TestMetrics
 
 trait WiremockSuite extends BeforeAndAfterAll with BeforeAndAfterEach {
   this: Suite =>
@@ -23,7 +25,9 @@ trait WiremockSuite extends BeforeAndAfterAll with BeforeAndAfterEach {
 
   protected lazy val injector: Injector = app.injector
 
-  protected def bindings: Seq[GuiceableModule] = Seq.empty
+  protected def bindings: Seq[GuiceableModule] = Seq(
+    bind[Metrics].toInstance(new TestMetrics)
+  )
 
   override def beforeAll(): Unit = {
     server.start()

--- a/it/utils/TestMetrics.scala
+++ b/it/utils/TestMetrics.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import com.kenshoo.play.metrics.Metrics
+import com.codahale.metrics.MetricRegistry
+
+class TestMetrics extends Metrics {
+  override def defaultRegistry: MetricRegistry = new MetricRegistry
+  override def toJson: String                  = ""
+}

--- a/test/controllers/ArrivalMessagesControllerSpec.scala
+++ b/test/controllers/ArrivalMessagesControllerSpec.scala
@@ -42,13 +42,18 @@ import uk.gov.hmrc.http.HttpResponse
 import utils.CallOps._
 
 import scala.concurrent.Future
+import com.kenshoo.play.metrics.Metrics
+import utils.TestMetrics
 
 class ArrivalMessagesControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAppPerSuite with OptionValues with ScalaFutures with MockitoSugar with BeforeAndAfterEach with TestXml {
   private val mockMessageConnector: ArrivalMessageConnector = mock[ArrivalMessageConnector]
 
   override lazy val app = GuiceApplicationBuilder()
-    .overrides(bind[AuthAction].to[FakeAuthAction])
-    .overrides(bind[ArrivalMessageConnector].toInstance(mockMessageConnector))
+    .overrides(
+      bind[Metrics].toInstance(new TestMetrics),
+      bind[AuthAction].to[FakeAuthAction],
+      bind[ArrivalMessageConnector].toInstance(mockMessageConnector)
+    )
     .build()
 
   override def beforeEach(): Unit = {

--- a/test/controllers/ArrivalMovementControllerSpec.scala
+++ b/test/controllers/ArrivalMovementControllerSpec.scala
@@ -19,6 +19,7 @@ package controllers
 import java.time.LocalDateTime
 
 import akka.util.ByteString
+import com.kenshoo.play.metrics.Metrics
 import connectors.ArrivalConnector
 import controllers.actions.{AuthAction, FakeAuthAction}
 import data.TestXml
@@ -40,6 +41,7 @@ import play.api.test.Helpers.{headers, _}
 import play.api.test.{FakeHeaders, FakeRequest}
 import uk.gov.hmrc.http.HttpResponse
 import utils.CallOps._
+import utils.TestMetrics
 
 import scala.concurrent.Future
 
@@ -47,8 +49,11 @@ class ArrivalMovementControllerSpec extends AnyFreeSpec with Matchers with Guice
   private val mockArrivalConnector: ArrivalConnector = mock[ArrivalConnector]
 
   override lazy val app = GuiceApplicationBuilder()
-    .overrides(bind[AuthAction].to[FakeAuthAction])
-    .overrides(bind[ArrivalConnector].toInstance(mockArrivalConnector))
+    .overrides(
+      bind[Metrics].toInstance(new TestMetrics),
+      bind[AuthAction].to[FakeAuthAction],
+      bind[ArrivalConnector].toInstance(mockArrivalConnector)
+    )
     .build()
 
   override def beforeEach(): Unit = {

--- a/test/controllers/DepartureMessagesControllerSpec.scala
+++ b/test/controllers/DepartureMessagesControllerSpec.scala
@@ -19,6 +19,7 @@ package controllers
 import java.time.LocalDateTime
 
 import akka.util.ByteString
+import com.kenshoo.play.metrics.Metrics
 import connectors.DepartureMessageConnector
 import controllers.actions.{AuthAction, FakeAuthAction}
 import data.TestXml
@@ -40,6 +41,7 @@ import play.api.test.Helpers.{headers, _}
 import play.api.test.{FakeHeaders, FakeRequest}
 import uk.gov.hmrc.http.HttpResponse
 import utils.CallOps._
+import utils.TestMetrics
 
 import scala.concurrent.Future
 
@@ -47,8 +49,11 @@ class DepartureMessagesControllerSpec extends AnyFreeSpec with Matchers with Gui
   private val mockMessageConnector: DepartureMessageConnector = mock[DepartureMessageConnector]
 
   override lazy val app = GuiceApplicationBuilder()
-    .overrides(bind[AuthAction].to[FakeAuthAction])
-    .overrides(bind[DepartureMessageConnector].toInstance(mockMessageConnector))
+    .overrides(
+      bind[Metrics].toInstance(new TestMetrics),
+      bind[AuthAction].to[FakeAuthAction],
+      bind[DepartureMessageConnector].toInstance(mockMessageConnector)
+    )
     .build()
 
   override def beforeEach(): Unit = {

--- a/test/controllers/DeparturesControllerSpec.scala
+++ b/test/controllers/DeparturesControllerSpec.scala
@@ -19,6 +19,7 @@ package controllers
 import java.time.LocalDateTime
 
 import audit.AuditService
+import com.kenshoo.play.metrics.Metrics
 import connectors.DeparturesConnector
 import controllers.actions.{AuthAction, FakeAuthAction}
 import data.TestXml
@@ -41,6 +42,7 @@ import play.api.test.{FakeHeaders, FakeRequest}
 import services.EnsureGuaranteeService
 import uk.gov.hmrc.http.HttpResponse
 import utils.CallOps._
+import utils.TestMetrics
 
 import scala.concurrent.Future
 
@@ -52,10 +54,13 @@ class DeparturesControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAp
   when(mockGuaranteeService.ensureGuarantee(any())).thenReturn(Right(CC015B))
 
   override lazy val app = GuiceApplicationBuilder()
-    .overrides(bind[AuthAction].to[FakeAuthAction])
-    .overrides(bind[DeparturesConnector].toInstance(mockDepartureConnector))
-    .overrides(bind[EnsureGuaranteeService].toInstance(mockGuaranteeService))
-    .overrides(bind[AuditService].toInstance(mockAuditService))
+    .overrides(
+      bind[Metrics].toInstance(new TestMetrics),
+      bind[AuthAction].to[FakeAuthAction],
+      bind[DeparturesConnector].toInstance(mockDepartureConnector),
+      bind[EnsureGuaranteeService].toInstance(mockGuaranteeService),
+      bind[AuditService].toInstance(mockAuditService)
+    )
     .build()
 
   override def beforeEach(): Unit = {

--- a/test/metrics/HasMetricsSpec.scala
+++ b/test/metrics/HasMetricsSpec.scala
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package metrics
+
+import com.codahale.metrics.Timer
+import com.kenshoo.play.metrics.Metrics
+import org.mockito.Mockito
+import org.mockito.Mockito._
+import org.mockito.ArgumentMatchers._
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.OptionValues
+import org.scalatest.compatible.Assertion
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpecLike
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.mvc.AbstractController
+import play.api.mvc.Results
+import play.api.test.FakeRequest
+import play.api.test.Helpers
+import scala.concurrent.Future
+
+class HasMetricsSpec extends AsyncWordSpecLike with Matchers with OptionValues with MockitoSugar with BeforeAndAfterAll {
+
+  trait MockHasMetrics {
+    self: HasMetrics =>
+    val timer                               = mock[Timer.Context]
+    val metrics                             = mock[Metrics]
+    override val localMetrics: LocalMetrics = mock[LocalMetrics]
+    when(localMetrics.startTimer(anyString())) thenReturn timer
+  }
+
+  class TestHasMetrics extends HasMetrics with MockHasMetrics
+
+  class TestHasActionMetrics extends AbstractController(Helpers.stubMessagesControllerComponents()) with HasActionMetrics with MockHasMetrics
+
+  def withTestMetrics[A](test: TestHasMetrics => A): A =
+    test(new TestHasMetrics)
+
+  def withTestActionMetrics[A](test: TestHasActionMetrics => A): A =
+    test(new TestHasActionMetrics)
+
+  def verifyCompletedWithSuccess(metricName: String, metrics: MockHasMetrics): Assertion = {
+    val inOrder = Mockito.inOrder(metrics.localMetrics, metrics.timer)
+    inOrder.verify(metrics.localMetrics, times(1)).startTimer(metricName)
+    inOrder.verify(metrics.localMetrics, times(1)).stopTimer(metrics.timer)
+    inOrder.verify(metrics.localMetrics, times(1)).incrementSuccessCounter(metricName)
+    verifyNoMoreInteractions(metrics.localMetrics)
+    verifyNoMoreInteractions(metrics.timer)
+    succeed
+  }
+
+  def verifyCompletedWithFailure(metricName: String, metrics: MockHasMetrics): Assertion = {
+    val inOrder = Mockito.inOrder(metrics.localMetrics, metrics.timer)
+    inOrder.verify(metrics.localMetrics, times(1)).startTimer(metricName)
+    inOrder.verify(metrics.localMetrics, times(1)).stopTimer(metrics.timer)
+    inOrder.verify(metrics.localMetrics, times(1)).incrementFailedCounter(metricName)
+    verifyNoMoreInteractions(metrics.localMetrics)
+    verifyNoMoreInteractions(metrics.timer)
+    succeed
+  }
+
+  val TestMetric = "test-metric"
+
+  "HasMetrics" when {
+    "withMetricsTimerAsync" should {
+      "increment success counter for a successful future" in withTestMetrics {
+        metrics =>
+          metrics.withMetricsTimerAsync(TestMetric)(_ => Future.successful(())).map {
+            _ =>
+              verifyCompletedWithSuccess(TestMetric, metrics)
+          }
+      }
+
+      "increment success counter for a successful future where completeWithSuccess is called explicitly" in withTestMetrics {
+        metrics =>
+          metrics
+            .withMetricsTimerAsync(TestMetric) {
+              timer =>
+                timer.completeWithSuccess()
+                Future.successful(())
+            }
+            .map(_ => verifyCompletedWithSuccess(TestMetric, metrics))
+      }
+
+      "increment failure counter for a failed future" in withTestMetrics {
+        metrics =>
+          metrics.withMetricsTimerAsync(TestMetric)(_ => Future.failed(new Exception)).recover {
+            case _ =>
+              verifyCompletedWithFailure(TestMetric, metrics)
+          }
+      }
+
+      "increment failure counter for a successful future where completeWithFailure is called explicitly" in withTestMetrics {
+        metrics =>
+          metrics
+            .withMetricsTimerAsync(TestMetric) {
+              timer =>
+                timer.completeWithFailure()
+                Future.successful(())
+            }
+            .map(_ => verifyCompletedWithFailure(TestMetric, metrics))
+      }
+
+      "only increment counters once regardless of how many times the user calls complete with success" in withTestMetrics {
+        metrics =>
+          metrics
+            .withMetricsTimerAsync(TestMetric) {
+              timer =>
+                Future(timer.completeWithSuccess())
+                Future(timer.completeWithSuccess())
+                Future(timer.completeWithSuccess())
+                Future(timer.completeWithSuccess())
+                Future.successful(())
+            }
+            .map(_ => verifyCompletedWithSuccess(TestMetric, metrics))
+      }
+
+      "only increment counters once regardless of how many times the user calls complete with failure" in withTestMetrics {
+        metrics =>
+          metrics
+            .withMetricsTimerAsync(TestMetric) {
+              timer =>
+                Future(timer.completeWithFailure())
+                Future(timer.completeWithFailure())
+                Future(timer.completeWithFailure())
+                Future(timer.completeWithFailure())
+                timer.completeWithFailure()
+                Future.successful(())
+            }
+            .map(_ => verifyCompletedWithFailure(TestMetric, metrics))
+      }
+
+      "increment failure counter when the user throws an exception constructing their code block" in withTestMetrics {
+        metrics =>
+          assertThrows[RuntimeException] {
+            metrics.withMetricsTimerAsync(TestMetric)(_ => Future.successful(throw new RuntimeException))
+          }
+
+          Future.successful(verifyCompletedWithFailure(TestMetric, metrics))
+      }
+    }
+
+    "withMetricsTimerResult" should {
+      "increment success counter for a successful future of an informational Result" in withTestMetrics {
+        metrics =>
+          metrics
+            .withMetricsTimerResult(TestMetric) {
+              Future.successful(Results.Continue)
+            }
+            .map(_ => verifyCompletedWithSuccess(TestMetric, metrics))
+      }
+
+      "increment success counter for a successful future of a successful Result" in withTestMetrics {
+        metrics =>
+          metrics
+            .withMetricsTimerResult(TestMetric) {
+              Future.successful(Results.Ok)
+            }
+            .map(_ => verifyCompletedWithSuccess(TestMetric, metrics))
+      }
+
+      "increment success counter for a successful future of a redirect Result" in withTestMetrics {
+        metrics =>
+          metrics
+            .withMetricsTimerResult(TestMetric) {
+              Future.successful(Results.NotModified)
+            }
+            .map(_ => verifyCompletedWithSuccess(TestMetric, metrics))
+      }
+
+      "increment failure counter for a successful future of a client error Result" in withTestMetrics {
+        metrics =>
+          metrics
+            .withMetricsTimerResult(TestMetric) {
+              Future.successful(Results.EntityTooLarge)
+            }
+            .map(_ => verifyCompletedWithFailure(TestMetric, metrics))
+      }
+
+      "increment failure counter for a successful future of a server error Result" in withTestMetrics {
+        metrics =>
+          metrics
+            .withMetricsTimerResult(TestMetric) {
+              Future.successful(Results.BadGateway)
+            }
+            .map(_ => verifyCompletedWithFailure(TestMetric, metrics))
+      }
+
+      "increment failure counter for a failed future" in withTestMetrics {
+        metrics =>
+          metrics
+            .withMetricsTimerResult(TestMetric) {
+              Future.failed(new Exception)
+            }
+            .transformWith {
+              case _ =>
+                verifyCompletedWithFailure(TestMetric, metrics)
+            }
+      }
+
+      "increment failure counter when the user throws an exception constructing their code block" in withTestMetrics {
+        metrics =>
+          assertThrows[RuntimeException] {
+            metrics.withMetricsTimerResult(TestMetric) {
+              Future.successful(throw new RuntimeException)
+            }
+          }
+
+          Future.successful(verifyCompletedWithFailure(TestMetric, metrics))
+      }
+    }
+
+    "withMetricsTimerAction" should {
+      def fakeRequest = FakeRequest()
+
+      "increment success counter for an informational Result" in withTestActionMetrics {
+        metrics =>
+          metrics
+            .withMetricsTimerAction(TestMetric) {
+              metrics.Action(Results.SwitchingProtocols)
+            }
+            .apply(fakeRequest)
+            .map(_ => verifyCompletedWithSuccess(TestMetric, metrics))
+      }
+
+      "increment success counter for a successful Result" in withTestActionMetrics {
+        metrics =>
+          metrics
+            .withMetricsTimerAction(TestMetric) {
+              metrics.Action(Results.Ok)
+            }
+            .apply(fakeRequest)
+            .map(_ => verifyCompletedWithSuccess(TestMetric, metrics))
+      }
+
+      "increment success counter for a redirect Result" in withTestActionMetrics {
+        metrics =>
+          metrics
+            .withMetricsTimerAction(TestMetric) {
+              metrics.Action(Results.Found("https://wikipedia.org"))
+            }
+            .apply(fakeRequest)
+            .map(_ => verifyCompletedWithSuccess(TestMetric, metrics))
+      }
+
+      "increment failure counter for a client error Result" in withTestActionMetrics {
+        metrics =>
+          metrics
+            .withMetricsTimerAction(TestMetric) {
+              metrics.Action(Results.Conflict)
+            }
+            .apply(fakeRequest)
+            .map(_ => verifyCompletedWithFailure(TestMetric, metrics))
+      }
+
+      "increment failure counter for a server error Result" in withTestActionMetrics {
+        metrics =>
+          metrics
+            .withMetricsTimerAction(TestMetric) {
+              metrics.Action(Results.ServiceUnavailable)
+            }
+            .apply(fakeRequest)
+            .map(_ => verifyCompletedWithFailure(TestMetric, metrics))
+      }
+    }
+  }
+
+}

--- a/test/utils/TestMetrics.scala
+++ b/test/utils/TestMetrics.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import com.kenshoo.play.metrics.Metrics
+import com.codahale.metrics.MetricRegistry
+
+class TestMetrics extends Metrics {
+  override def defaultRegistry: MetricRegistry = new MetricRegistry
+  override def toJson: String                  = ""
+}


### PR DESCRIPTION
Add metrics collection to the controllers and connectors in the API

I have used the convention of using the controller method name in our controllers, and in using `<movement type>-backend-<http method>` in the connectors.