### PR TITLE
CTDA-1308 Filter arrival messages by last updated timestamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ modules
 /out
 precompiled
 /.project
-project/project
 project/target
 /RUNNING_PID
 server.pid

--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -16,9 +16,12 @@
 
 package config
 
-import javax.inject.{Inject, Singleton}
+import io.lemonlabs.uri.Url
 import play.api.Configuration
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+
+import javax.inject.Inject
+import javax.inject.Singleton
 
 @Singleton
 class AppConfig @Inject()(config: Configuration, servicesConfig: ServicesConfig) {
@@ -28,8 +31,8 @@ class AppConfig @Inject()(config: Configuration, servicesConfig: ServicesConfig)
   val auditingEnabled: Boolean  = config.get[Boolean]("auditing.enabled")
   val graphiteHost: String      = config.get[String]("microservice.metrics.graphite.host")
 
-  val traderAtDestinationUrl    = servicesConfig.baseUrl("transit-movement-trader-at-destination")
-  val traderAtDeparturesUrl     = servicesConfig.baseUrl("transits-movements-trader-at-departure")
+  val traderAtDestinationUrl    = Url.parse(servicesConfig.baseUrl("transit-movement-trader-at-destination"))
+  val traderAtDeparturesUrl     = Url.parse(servicesConfig.baseUrl("transits-movements-trader-at-departure"))
 
   lazy val enrolmentKey: String = config.get[String]("security.enrolmentKey")
 

--- a/app/connectors/ArrivalConnector.scala
+++ b/app/connectors/ArrivalConnector.scala
@@ -16,18 +16,20 @@
 
 package connectors
 
-import javax.inject.Inject
-
 import com.kenshoo.play.metrics.Metrics
 import config.AppConfig
 import connectors.util.CustomHttpReader
-import metrics.{HasMetrics, MetricsKeys}
+import metrics.HasMetrics
+import metrics.MetricsKeys
 import models.domain.Arrival
 import models.domain.Arrivals
 import play.api.mvc.RequestHeader
-import uk.gov.hmrc.http.{HttpClient, HttpResponse, HeaderCarrier}
-import utils.Utils
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.HttpClient
+import uk.gov.hmrc.http.HttpResponse
 
+import java.time.OffsetDateTime
+import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
@@ -37,32 +39,34 @@ class ArrivalConnector @Inject() (http: HttpClient, appConfig: AppConfig, val me
 
   def post(message: String)(implicit requestHeader: RequestHeader, hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] =
     withMetricsTimerResponse(Post) {
-      val url = appConfig.traderAtDestinationUrl + arrivalRoute
-      http.POSTString(url, message)(CustomHttpReader, enforceAuthHeaderCarrier(requestHeaders), ec)
+      val url = appConfig.traderAtDestinationUrl.withPath(arrivalRoute)
+      http.POSTString(url.toString, message)(CustomHttpReader, enforceAuthHeaderCarrier(requestHeaders), ec)
     }
 
   def put(message: String, arrivalId: String)(implicit requestHeader: RequestHeader, headerCarrier: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] =
     withMetricsTimerResponse(Put) {
-      val url = appConfig.traderAtDestinationUrl + arrivalRoute + Utils.urlEncode(arrivalId)
-      http.PUTString(url, message)(CustomHttpReader, enforceAuthHeaderCarrier(requestHeaders), ec)
+      val url = appConfig.traderAtDestinationUrl.withPath(arrivalRoute).addPathPart(arrivalId)
+      http.PUTString(url.toString, message)(CustomHttpReader, enforceAuthHeaderCarrier(requestHeaders), ec)
     }
 
   def get(arrivalId: String)(implicit requestHeader: RequestHeader, hc: HeaderCarrier, ec: ExecutionContext): Future[Either[HttpResponse, Arrival]] =
     withMetricsTimerAsync(GetById) {
       timer =>
-        val url = appConfig.traderAtDestinationUrl + arrivalRoute + Utils.urlEncode(arrivalId)
-        http.GET[HttpResponse](url, queryParams = Seq(), responseHeaders)(CustomHttpReader, enforceAuthHeaderCarrier(responseHeaders), ec).map {
+        val url = appConfig.traderAtDestinationUrl.withPath(arrivalRoute).addPathPart(arrivalId)
+        http.GET[HttpResponse](url.toString, queryParams = Seq(), responseHeaders)(CustomHttpReader, enforceAuthHeaderCarrier(responseHeaders), ec).map {
           response =>
             if (is2xx(response.status)) timer.completeWithSuccess() else timer.completeWithFailure()
             extractIfSuccessful[Arrival](response)
         }
     }
 
-  def getForEori()(implicit requestHeader: RequestHeader, hc: HeaderCarrier, ec: ExecutionContext): Future[Either[HttpResponse, Arrivals]] =
+  def getForEori(updatedSince: Option[OffsetDateTime])(implicit requestHeader: RequestHeader, hc: HeaderCarrier, ec: ExecutionContext): Future[Either[HttpResponse, Arrivals]] =
     withMetricsTimerAsync(GetForEori) {
       timer =>
-        val url = appConfig.traderAtDestinationUrl + arrivalRoute
-        http.GET[HttpResponse](url, queryParams = Seq(), responseHeaders)(CustomHttpReader, enforceAuthHeaderCarrier(responseHeaders), ec).map {
+        val url = appConfig.traderAtDestinationUrl.withPath(arrivalRoute)
+        val query = updatedSince.map(dt => Seq("updated_since" -> queryDateFormatter.format(dt))).getOrElse(Seq.empty)
+
+        http.GET[HttpResponse](url.toString, queryParams = query, responseHeaders)(CustomHttpReader, enforceAuthHeaderCarrier(responseHeaders), ec).map {
           response =>
             if (is2xx(response.status)) timer.completeWithSuccess() else timer.completeWithFailure()
             extractIfSuccessful[Arrivals](response)

--- a/app/connectors/ArrivalConnector.scala
+++ b/app/connectors/ArrivalConnector.scala
@@ -64,7 +64,7 @@ class ArrivalConnector @Inject() (http: HttpClient, appConfig: AppConfig, val me
     withMetricsTimerAsync(GetForEori) {
       timer =>
         val url = appConfig.traderAtDestinationUrl.withPath(arrivalRoute)
-        val query = updatedSince.map(dt => Seq("updated_since" -> queryDateFormatter.format(dt))).getOrElse(Seq.empty)
+        val query = updatedSince.map(dt => Seq("updatedSince" -> queryDateFormatter.format(dt))).getOrElse(Seq.empty)
 
         http.GET[HttpResponse](url.toString, queryParams = query, responseHeaders)(CustomHttpReader, enforceAuthHeaderCarrier(responseHeaders), ec).map {
           response =>

--- a/app/connectors/BaseConnector.scala
+++ b/app/connectors/BaseConnector.scala
@@ -18,12 +18,18 @@ package connectors
 
 import connectors.util.CustomHttpReader
 import connectors.util.CustomHttpReader.INTERNAL_SERVER_ERROR
+import io.lemonlabs.uri.UrlPath
 import models.ChannelType.api
-import play.api.http.{HeaderNames, MimeTypes}
+import play.api.http.HeaderNames
+import play.api.http.MimeTypes
 import play.api.libs.json.Reads
 import play.api.mvc.RequestHeader
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.HttpErrorFunctions
+import uk.gov.hmrc.http.HttpResponse
 import uk.gov.hmrc.http.logging.Authorization
-import uk.gov.hmrc.http.{HeaderCarrier, HttpErrorFunctions, HttpResponse}
+
+import java.time.format.DateTimeFormatter
 
 class BaseConnector extends HttpErrorFunctions {
 
@@ -34,9 +40,11 @@ class BaseConnector extends HttpErrorFunctions {
   protected val responseHeaders: Seq[(String, String)] =
     Seq((HeaderNames.CONTENT_TYPE, MimeTypes.JSON), channelHeader)
 
-  protected val arrivalRoute = "/transit-movements-trader-at-destination/movements/arrivals/"
+  protected val arrivalRoute = UrlPath.parse("/transit-movements-trader-at-destination/movements/arrivals")
 
-  protected val departureRoute = "/transits-movements-trader-at-departure/movements/departures/"
+  protected val departureRoute = UrlPath.parse("/transits-movements-trader-at-departure/movements/departures")
+
+  protected val queryDateFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
 
   protected def extractIfSuccessful[T](response: HttpResponse)(implicit reads: Reads[T]): Either[HttpResponse, T] =
     if(is2xx(response.status)) {

--- a/app/controllers/ArrivalMovementController.scala
+++ b/app/controllers/ArrivalMovementController.scala
@@ -16,14 +16,13 @@
 
 package controllers
 
-import javax.inject.Inject
-
 import com.kenshoo.play.metrics.Metrics
 import connectors.ArrivalConnector
 import controllers.actions.AuthAction
 import controllers.actions.ValidateAcceptJsonHeaderAction
 import controllers.actions.ValidateArrivalNotificationAction
-import metrics.{HasActionMetrics, MetricsKeys}
+import metrics.HasActionMetrics
+import metrics.MetricsKeys
 import models.MessageType
 import models.domain.Arrivals
 import models.response.HateaosArrivalMovementPostResponseMessage
@@ -39,6 +38,8 @@ import utils.CallOps._
 import utils.ResponseHelper
 import utils.Utils
 
+import java.time.OffsetDateTime
+import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 import scala.xml.NodeSeq
 
@@ -141,11 +142,11 @@ class ArrivalMovementController @Inject() (
       }
     }
 
-  def getArrivalsForEori: Action[AnyContent] =
+  def getArrivalsForEori(updatedSince: Option[OffsetDateTime]): Action[AnyContent] =
     withMetricsTimerAction(GetArrivalsForEori) {
       (authAction andThen validateAcceptJsonHeaderAction).async {
         implicit request =>
-          arrivalConnector.getForEori.map {
+          arrivalConnector.getForEori(updatedSince).map {
             case Right(arrivals: Arrivals) =>
               arrivalsCount.update(arrivals.arrivals.length)
               Ok(Json.toJson(HateaosResponseArrivals(arrivals)))

--- a/app/models/Binders.scala
+++ b/app/models/Binders.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+import play.api.mvc.QueryStringBindable
+
+object Binders {
+  implicit val offsetDateTimeQueryStringBindable: QueryStringBindable[OffsetDateTime] = {
+    val formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+    new QueryStringBindable.Parsing[OffsetDateTime](
+      OffsetDateTime.parse(_),
+      dt => formatter.format(dt),
+      (param, _) => s"Cannot parse parameter $param as a valid ISO 8601 timestamp, e.g. 2015-09-08T01:55:28+00:00"
+    )
+  }
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,4 +1,4 @@
-GET        /movements/arrivals                                      controllers.ArrivalMovementController.getArrivalsForEori(updated_since: Option[OffsetDateTime] ?= None)
+GET        /movements/arrivals                                      controllers.ArrivalMovementController.getArrivalsForEori(updatedSince: Option[OffsetDateTime] ?= None)
 POST       /movements/arrivals                                      controllers.ArrivalMovementController.createArrivalNotification()
 
 PUT        /movements/arrivals/:arrivalId                           controllers.ArrivalMovementController.resubmitArrivalNotification(arrivalId: String)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,4 +1,4 @@
-GET        /movements/arrivals                                      controllers.ArrivalMovementController.getArrivalsForEori()
+GET        /movements/arrivals                                      controllers.ArrivalMovementController.getArrivalsForEori(updated_since: Option[OffsetDateTime] ?= None)
 POST       /movements/arrivals                                      controllers.ArrivalMovementController.createArrivalNotification()
 
 PUT        /movements/arrivals/:arrivalId                           controllers.ArrivalMovementController.resubmitArrivalNotification(arrivalId: String)

--- a/it/connectors/ArrivalConnectorSpec.scala
+++ b/it/connectors/ArrivalConnectorSpec.scala
@@ -32,6 +32,8 @@ import uk.gov.hmrc.http.HeaderCarrier
 import utils.CallOps._
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 
 class ArrivalConnectorSpec extends AnyFreeSpec with Matchers with WiremockSuite with ScalaFutures with IntegrationPatience with ScalaCheckPropertyChecks {
   "post" - {
@@ -239,6 +241,23 @@ class ArrivalConnectorSpec extends AnyFreeSpec with Matchers with WiremockSuite 
       implicit val requestHeader = FakeRequest()
 
       val result = connector.getForEori(None).futureValue
+
+      result mustEqual Right(arrivals)
+    }
+
+    "must render updated_since parameter into request URL" in {
+      val connector = app.injector.instanceOf[ArrivalConnector]
+      val arrivals = Arrivals(Seq(Arrival(1, routes.ArrivalMovementController.getArrival("1").urlWithContext, routes.ArrivalMessagesController.getArrivalMessages("1").urlWithContext, "MRN", "status", LocalDateTime.now, LocalDateTime.now)))
+      val dateTime = Some(OffsetDateTime.of(2021, 3, 14, 13, 15, 30, 0, ZoneOffset.ofHours(1)))
+
+      server.stubFor(get(urlEqualTo("/transit-movements-trader-at-destination/movements/arrivals?updated_since=2021-03-14T13%3A15%3A30%2B01%3A00"))
+        .willReturn(aResponse().withStatus(OK)
+          .withBody(Json.toJson(arrivals).toString())))
+
+      implicit val hc = HeaderCarrier()
+      implicit val requestHeader = FakeRequest()
+
+      val result = connector.getForEori(dateTime).futureValue
 
       result mustEqual Right(arrivals)
     }

--- a/it/connectors/ArrivalConnectorSpec.scala
+++ b/it/connectors/ArrivalConnectorSpec.scala
@@ -245,12 +245,12 @@ class ArrivalConnectorSpec extends AnyFreeSpec with Matchers with WiremockSuite 
       result mustEqual Right(arrivals)
     }
 
-    "must render updated_since parameter into request URL" in {
+    "must render updatedSince parameter into request URL" in {
       val connector = app.injector.instanceOf[ArrivalConnector]
       val arrivals = Arrivals(Seq(Arrival(1, routes.ArrivalMovementController.getArrival("1").urlWithContext, routes.ArrivalMessagesController.getArrivalMessages("1").urlWithContext, "MRN", "status", LocalDateTime.now, LocalDateTime.now)))
       val dateTime = Some(OffsetDateTime.of(2021, 3, 14, 13, 15, 30, 0, ZoneOffset.ofHours(1)))
 
-      server.stubFor(get(urlEqualTo("/transit-movements-trader-at-destination/movements/arrivals?updated_since=2021-03-14T13%3A15%3A30%2B01%3A00"))
+      server.stubFor(get(urlEqualTo("/transit-movements-trader-at-destination/movements/arrivals?updatedSince=2021-03-14T13%3A15%3A30%2B01%3A00"))
         .willReturn(aResponse().withStatus(OK)
           .withBody(Json.toJson(arrivals).toString())))
 

--- a/it/connectors/ArrivalConnectorSpec.scala
+++ b/it/connectors/ArrivalConnectorSpec.scala
@@ -40,7 +40,7 @@ class ArrivalConnectorSpec extends AnyFreeSpec with Matchers with WiremockSuite 
 
       server.stubFor(
         post(
-          urlEqualTo("/transit-movements-trader-at-destination/movements/arrivals/")
+          urlEqualTo("/transit-movements-trader-at-destination/movements/arrivals")
         ).willReturn(aResponse().withStatus(ACCEPTED))
       )
 
@@ -58,7 +58,7 @@ class ArrivalConnectorSpec extends AnyFreeSpec with Matchers with WiremockSuite 
 
         server.stubFor(
           post(
-            urlEqualTo("/transit-movements-trader-at-destination/movements/arrivals/")
+            urlEqualTo("/transit-movements-trader-at-destination/movements/arrivals")
           ).willReturn(aResponse().withStatus(INTERNAL_SERVER_ERROR))
         )
 
@@ -77,7 +77,7 @@ class ArrivalConnectorSpec extends AnyFreeSpec with Matchers with WiremockSuite 
 
       server.stubFor(
         post(
-          urlEqualTo("/transit-movements-trader-at-destination/movements/arrivals/")
+          urlEqualTo("/transit-movements-trader-at-destination/movements/arrivals")
         ).willReturn(aResponse().withStatus(BAD_REQUEST))
       )
 
@@ -231,14 +231,14 @@ class ArrivalConnectorSpec extends AnyFreeSpec with Matchers with WiremockSuite 
       val connector = app.injector.instanceOf[ArrivalConnector]
       val arrivals = Arrivals(Seq(Arrival(1, routes.ArrivalMovementController.getArrival("1").urlWithContext, routes.ArrivalMessagesController.getArrivalMessages("1").urlWithContext, "MRN", "status", LocalDateTime.now, LocalDateTime.now)))
 
-      server.stubFor(get(urlEqualTo("/transit-movements-trader-at-destination/movements/arrivals/"))
+      server.stubFor(get(urlEqualTo("/transit-movements-trader-at-destination/movements/arrivals"))
         .willReturn(aResponse().withStatus(OK)
           .withBody(Json.toJson(arrivals).toString())))
 
       implicit val hc = HeaderCarrier()
       implicit val requestHeader = FakeRequest()
 
-      val result = connector.getForEori.futureValue
+      val result = connector.getForEori(None).futureValue
 
       result mustEqual Right(arrivals)
     }
@@ -249,14 +249,14 @@ class ArrivalConnectorSpec extends AnyFreeSpec with Matchers with WiremockSuite 
 
       val response = HateaosResponseArrivals(arrival)
 
-      server.stubFor(get(urlEqualTo("/transit-movements-trader-at-destination/movements/arrivals/"))
+      server.stubFor(get(urlEqualTo("/transit-movements-trader-at-destination/movements/arrivals"))
         .willReturn(aResponse().withStatus(OK)
         .withBody(Json.toJson(response).toString())))
 
       implicit val hc = HeaderCarrier()
       implicit val requestHeader = FakeRequest()
 
-      val result = connector.getForEori.futureValue
+      val result = connector.getForEori(None).futureValue
 
       result.isLeft mustEqual true
       result.left.map { x => x.status mustEqual INTERNAL_SERVER_ERROR }
@@ -264,13 +264,13 @@ class ArrivalConnectorSpec extends AnyFreeSpec with Matchers with WiremockSuite 
 
     "must return HttpResponse with a not found if not found" in {
       val connector = app.injector.instanceOf[ArrivalConnector]
-      server.stubFor(get(urlEqualTo("/transit-movements-trader-at-destination/movements/arrivals/"))
+      server.stubFor(get(urlEqualTo("/transit-movements-trader-at-destination/movements/arrivals"))
         .willReturn(aResponse().withStatus(NOT_FOUND)))
 
       implicit val hc = HeaderCarrier()
       implicit val requestHeader = FakeRequest()
 
-      val result = connector.getForEori.futureValue
+      val result = connector.getForEori(None).futureValue
 
       result.isLeft mustEqual true
       result.left.map { x => x.status mustEqual NOT_FOUND }
@@ -278,13 +278,13 @@ class ArrivalConnectorSpec extends AnyFreeSpec with Matchers with WiremockSuite 
 
     "must return HttpResponse with a bad request if there is a bad request" in {
       val connector = app.injector.instanceOf[ArrivalConnector]
-      server.stubFor(get(urlEqualTo("/transit-movements-trader-at-destination/movements/arrivals/"))
+      server.stubFor(get(urlEqualTo("/transit-movements-trader-at-destination/movements/arrivals"))
         .willReturn(aResponse().withStatus(BAD_REQUEST)))
 
       implicit val hc = HeaderCarrier()
       implicit val requestHeader = FakeRequest()
 
-      val result = connector.getForEori.futureValue
+      val result = connector.getForEori(None).futureValue
 
       result.isLeft mustEqual true
       result.left.map { x => x.status mustEqual BAD_REQUEST }
@@ -292,13 +292,13 @@ class ArrivalConnectorSpec extends AnyFreeSpec with Matchers with WiremockSuite 
 
     "must return HttpResponse with an internal server if there is an internal server error" in {
       val connector = app.injector.instanceOf[ArrivalConnector]
-      server.stubFor(get(urlEqualTo("/transit-movements-trader-at-destination/movements/arrivals/"))
+      server.stubFor(get(urlEqualTo("/transit-movements-trader-at-destination/movements/arrivals"))
         .willReturn(aResponse().withStatus(INTERNAL_SERVER_ERROR)))
 
       implicit val hc = HeaderCarrier()
       implicit val requestHeader = FakeRequest()
 
-      val result = connector.getForEori.futureValue
+      val result = connector.getForEori(None).futureValue
 
       result.isLeft mustEqual true
       result.left.map { x => x.status mustEqual INTERNAL_SERVER_ERROR }

--- a/it/connectors/DepartureConnectorSpec.scala
+++ b/it/connectors/DepartureConnectorSpec.scala
@@ -40,7 +40,7 @@ class DepartureConnectorSpec extends AnyFreeSpec with Matchers with WiremockSuit
 
       server.stubFor(
         post(
-          urlEqualTo("/transits-movements-trader-at-departure/movements/departures/")
+          urlEqualTo("/transits-movements-trader-at-departure/movements/departures")
         ).willReturn(aResponse().withStatus(ACCEPTED))
       )
 
@@ -58,7 +58,7 @@ class DepartureConnectorSpec extends AnyFreeSpec with Matchers with WiremockSuit
 
         server.stubFor(
           post(
-            urlEqualTo("/transits-movements-trader-at-departure/movements/departures/")
+            urlEqualTo("/transits-movements-trader-at-departure/movements/departures")
           ).willReturn(aResponse().withStatus(INTERNAL_SERVER_ERROR))
         )
 
@@ -77,7 +77,7 @@ class DepartureConnectorSpec extends AnyFreeSpec with Matchers with WiremockSuit
 
       server.stubFor(
         post(
-          urlEqualTo("/transits-movements-trader-at-departure/movements/departures/")
+          urlEqualTo("/transits-movements-trader-at-departure/movements/departures")
         ).willReturn(aResponse().withStatus(BAD_REQUEST))
       )
 
@@ -173,7 +173,7 @@ class DepartureConnectorSpec extends AnyFreeSpec with Matchers with WiremockSuit
       val connector = app.injector.instanceOf[DeparturesConnector]
       val departures = Departures(Seq(Departure(1, routes.DeparturesController.getDeparture("1").urlWithContext, routes.DepartureMessagesController.getDepartureMessages("1").urlWithContext, Some("1"), "status", LocalDateTime.now, LocalDateTime.now)))
 
-      server.stubFor(get(urlEqualTo("/transits-movements-trader-at-departure/movements/departures/"))
+      server.stubFor(get(urlEqualTo("/transits-movements-trader-at-departure/movements/departures"))
         .willReturn(aResponse().withStatus(OK)
           .withBody(Json.toJson(departures).toString())))
 
@@ -191,7 +191,7 @@ class DepartureConnectorSpec extends AnyFreeSpec with Matchers with WiremockSuit
 
       val response = HateaosResponseDepartures(departures)
 
-      server.stubFor(get(urlEqualTo("/transits-movements-trader-at-departure/movements/departures/"))
+      server.stubFor(get(urlEqualTo("/transits-movements-trader-at-departure/movements/departures"))
         .willReturn(aResponse().withStatus(OK)
         .withBody(Json.toJson(response).toString())))
 
@@ -206,7 +206,7 @@ class DepartureConnectorSpec extends AnyFreeSpec with Matchers with WiremockSuit
 
     "must return HttpResponse with a not found if not found" in {
       val connector = app.injector.instanceOf[DeparturesConnector]
-      server.stubFor(get(urlEqualTo("/transits-movements-trader-at-departure/movements/departures/"))
+      server.stubFor(get(urlEqualTo("/transits-movements-trader-at-departure/movements/departures"))
         .willReturn(aResponse().withStatus(NOT_FOUND)))
 
       implicit val hc = HeaderCarrier()
@@ -220,7 +220,7 @@ class DepartureConnectorSpec extends AnyFreeSpec with Matchers with WiremockSuit
 
     "must return HttpResponse with a bad request if there is a bad request" in {
       val connector = app.injector.instanceOf[DeparturesConnector]
-      server.stubFor(get(urlEqualTo("/transits-movements-trader-at-departure/movements/departures/"))
+      server.stubFor(get(urlEqualTo("/transits-movements-trader-at-departure/movements/departures"))
         .willReturn(aResponse().withStatus(BAD_REQUEST)))
 
       implicit val hc = HeaderCarrier()
@@ -234,7 +234,7 @@ class DepartureConnectorSpec extends AnyFreeSpec with Matchers with WiremockSuit
 
     "must return HttpResponse with an internal server if there is an internal server error" in {
       val connector = app.injector.instanceOf[DeparturesConnector]
-      server.stubFor(get(urlEqualTo("/transits-movements-trader-at-departure/movements/departures/"))
+      server.stubFor(get(urlEqualTo("/transits-movements-trader-at-departure/movements/departures"))
         .willReturn(aResponse().withStatus(INTERNAL_SERVER_ERROR)))
 
       implicit val hc = HeaderCarrier()

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,23 +6,23 @@ object AppDependencies {
   private val catsVersion = "2.1.1"
 
   val compile = Seq(
-    "uk.gov.hmrc"       %% "bootstrap-backend-play-27"   % "3.3.0",
-    "org.typelevel"     %% "cats-core"                 % catsVersion,
-    "org.json"          % "json"                             % "20200518"
+    "uk.gov.hmrc"   %% "bootstrap-backend-play-27" % "3.4.0",
+    "org.typelevel" %% "cats-core"                 % catsVersion,
+    "org.json"       % "json"                      % "20200518",
+    "io.lemonlabs"  %% "scala-uri"                 % "3.2.0"
   )
 
   val test = Seq(
-    "org.mockito"            % "mockito-core"          % "3.3.3",
-    "org.scalatest"          %% "scalatest"            % "3.2.0",
-    "org.typelevel"     %% "cats-core"                 % catsVersion,
+    "org.mockito"             % "mockito-core"         % "3.9.0",
+    "org.scalatest"          %% "scalatest"            % "3.2.8",
+    "org.typelevel"          %% "cats-core"            % catsVersion,
     "com.typesafe.play"      %% "play-test"            % current,
-    "org.pegdown"            % "pegdown"               % "1.6.0",
+    "org.pegdown"             % "pegdown"              % "1.6.0",
     "org.scalatestplus.play" %% "scalatestplus-play"   % "4.0.3",
     "org.scalatestplus"      %% "mockito-3-2"          % "3.1.2.0",
     "org.scalacheck"         %% "scalacheck"           % "1.14.3",
-    "com.github.tomakehurst" % "wiremock-standalone"   % "2.27.1",
-    "org.typelevel"          %% "discipline-scalatest" % "1.0.1",
-    "com.vladsch.flexmark"   % "flexmark-all"          % "0.35.10"
-
+    "com.github.tomakehurst"  % "wiremock-standalone"  % "2.27.2",
+    "org.typelevel"          %% "discipline-scalatest" % "2.1.4",
+    "com.vladsch.flexmark"    % "flexmark-all"         % "0.35.10"
   ).map(_ % "test, it")
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 
 object AppDependencies {
 
-  private val catsVersion = "2.1.1"
+  private val catsVersion = "2.5.0"
 
   val compile = Seq(
     "uk.gov.hmrc"   %% "bootstrap-backend-play-27" % "3.4.0",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,18 +2,20 @@ resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.
 
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.14.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.15.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.2.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.3.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.15.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.9")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.7.0")
 
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.16")
+
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.3")
 
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.17")

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.3")

--- a/resources/public/api/conf/1.0/application.raml
+++ b/resources/public/api/conf/1.0/application.raml
@@ -53,7 +53,7 @@ traits:
 
         The response will contain a URI and arrival ID for the Arrival Notification. This will allow you to get the message status.
 
-        If the user is not enrolled for an Economic Operator Registration and Identification number, they will receive an HTTP 403 Forbidden status. 
+        If the user is not enrolled for an Economic Operator Registration and Identification number, they will receive an HTTP 403 Forbidden status.
       is: [contentXmlHeader]
       (annotations.scope): "common-transit-convention-traders"
       securedBy: [ sec.oauth_2_0: { scopes: [ "common-transit-convention-traders" ] } ]
@@ -78,10 +78,18 @@ traits:
       description: |
         Get all Movement Arrivals.
 
+        You may opt to filter this list of Arrivals so that you only receive Movement Arrivals that have been updated since a specified date and time.
+
         Any Movement Arrivals more than 28 days old will have been archived along with their related messages. Archived movements will return an HTTP 404 Not Found status. You will only be able to retrieve these messages if you have the correct Economic Operator Registration and Identification (EORI) number for that Movement Arrival.
       is:
         - headers.acceptHeader
         - acceptHeaderInvalid
+      queryParameters:
+        updated_since:
+          required: false
+          type: datetime
+          description: This is an optional filtering parameter. It allows you to request only the Movement Arrivals which have been updated since the date and time you have given us.
+          example: 2021-06-21T09:00+00:00
       (annotations.scope): "common-transit-convention-traders"
       securedBy: [ sec.oauth_2_0: { scopes: [ "common-transit-convention-traders" ] } ]
       responses:
@@ -339,7 +347,7 @@ traits:
       displayName: Send a Declaration Data message
       description: |
         Send a Declaration Data message, to let the office at destination know that the goods are on their way. This notification will be sent when the goods leave the Office of Departure. It is also called an E_DEC_DAT (IE015).
-        
+
         The response will contain a URI and departure ID for the Declaration Data. This will allow you to retrieve the submission status.
 
         If the user is not enrolled for an EORI number, they will receive an HTTP Forbidden Status.
@@ -372,7 +380,7 @@ traits:
         You will only be able to retrieve these messages if you have the correct Economic Operator Registration and Identification (EORI) number for that Movement Departure.
 
         **Note**: The 'movementReferenceNumber' field will only be populated when an MRN is allocated.
-      is: 
+      is:
         - headers.acceptHeader
         - acceptHeaderInvalid
       (annotations.scope): "common-transit-convention-traders"
@@ -428,12 +436,12 @@ traits:
       get:
         displayName: Get a Movement Departure for a departure ID
         description: |
-          Get a specific Movement Departure which was sent to the office at departure within 28 days of the goods being released at their final destination. Any Movements that are more than 28 days old will have been archived. Archived notifications will be return an HTTP 404 Not Found status. 
+          Get a specific Movement Departure which was sent to the office at departure within 28 days of the goods being released at their final destination. Any Movements that are more than 28 days old will have been archived. Archived notifications will be return an HTTP 404 Not Found status.
 
           You will only be able to retrieve these messages if you have the EORI number associated with the Movement Departure.
 
           **Note**: The 'movementReferenceNumber' field will only be populated when an MRN is allocated.
-        is: 
+        is:
           - headers.acceptHeader
           - acceptHeaderInvalid
         (annotations.scope): "common-transit-convention-traders"
@@ -497,12 +505,12 @@ traits:
         get:
           displayName: Get all messages relating to a Movement Departure
           description: |
-            Get all messages sent within 28 days of the goods being released relating to a Movement Departure. Any Movements that are more than 28 days old will have been archived. Archived notifications will be return an HTTP 404 Not Found status. 
+            Get all messages sent within 28 days of the goods being released relating to a Movement Departure. Any Movements that are more than 28 days old will have been archived. Archived notifications will be return an HTTP 404 Not Found status.
 
             You will only be able to retrieve these messages if you have the EORI number associated with the Movement Departure.
 
             **Note**: The 'movementReferenceNumber' field will only be populated when an MRN is allocated.
-          is: 
+          is:
             - headers.acceptHeader
             - acceptHeaderInvalid
           (annotations.scope): "common-transit-convention-traders"
@@ -560,7 +568,7 @@ traits:
           get:
             displayName: Get a message relating to a Movement Departure and message ID
             description: |
-              Get all messages relating to a specific Movement Departure and message ID. For example, this could include declaration rejected or Movement Reference Number (MRN) allocated messages. Any messages more than 28 days old will be archived. Archived notifications will be return an HTTP 404 Not Found status. 
+              Get all messages relating to a specific Movement Departure and message ID. For example, this could include declaration rejected or Movement Reference Number (MRN) allocated messages. Any messages more than 28 days old will be archived. Archived notifications will be return an HTTP 404 Not Found status.
 
               You will only be able to retrieve these messages if you have the EORI number associated with the Movement Departure.
             is:

--- a/resources/public/api/conf/1.0/application.raml
+++ b/resources/public/api/conf/1.0/application.raml
@@ -85,7 +85,7 @@ traits:
         - headers.acceptHeader
         - acceptHeaderInvalid
       queryParameters:
-        updated_since:
+        updatedSince:
           required: false
           type: datetime
           description: This is an optional filtering parameter. It allows you to request only the Movement Arrivals which have been updated since the date and time you have given us.

--- a/test/controllers/ArrivalMovementControllerSpec.scala
+++ b/test/controllers/ArrivalMovementControllerSpec.scala
@@ -16,33 +16,43 @@
 
 package controllers
 
-import java.time.LocalDateTime
-
 import akka.util.ByteString
 import com.kenshoo.play.metrics.Metrics
 import connectors.ArrivalConnector
-import controllers.actions.{AuthAction, FakeAuthAction}
+import controllers.actions.AuthAction
+import controllers.actions.FakeAuthAction
 import data.TestXml
-import models.domain.{Arrival, Arrivals}
+import models.domain.Arrival
+import models.domain.Arrivals
+import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{reset, when}
+import org.mockito.Mockito.reset
+import org.mockito.Mockito.when
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.OptionValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
-import org.scalatest.{BeforeAndAfterEach, OptionValues}
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.http.HeaderNames
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.libs.json.{JsNull, Json}
-import play.api.mvc.{AnyContentAsEmpty, Headers}
-import play.api.test.Helpers.{headers, _}
-import play.api.test.{FakeHeaders, FakeRequest}
+import play.api.libs.json.JsNull
+import play.api.libs.json.Json
+import play.api.mvc.AnyContentAsEmpty
+import play.api.mvc.Headers
+import play.api.test.FakeHeaders
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import play.api.test.Helpers.headers
 import uk.gov.hmrc.http.HttpResponse
 import utils.CallOps._
 import utils.TestMetrics
 
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import scala.concurrent.Future
 
 class ArrivalMovementControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAppPerSuite with OptionValues with ScalaFutures with MockitoSugar with BeforeAndAfterEach with TestXml {
@@ -488,6 +498,20 @@ class ArrivalMovementControllerSpec extends AnyFreeSpec with Matchers with Guice
 
      status(result) mustBe OK
      contentAsString(result) mustEqual expectedJson.toString()
+   }
+
+   "pass updated_since parameter on to connector" in {
+    val argCaptor = ArgumentCaptor.forClass(classOf[Option[OffsetDateTime]])
+    val dateTime = Some(OffsetDateTime.of(2021, 6, 23, 12, 1, 24, 0, ZoneOffset.UTC))
+
+    when(mockArrivalConnector.getForEori(argCaptor.capture())(any(), any(), any()))
+      .thenReturn(Future.successful(Right(Arrivals(Nil))))
+
+     val request = FakeRequest("GET", routes.ArrivalMovementController.getArrivalsForEori(dateTime).url, headers = FakeHeaders(Seq(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")), AnyContentAsEmpty)
+     val result = route(app, request).value
+
+     status(result) mustBe OK
+     argCaptor.getValue() mustBe dateTime
    }
 
    "return 500 for downstream errors" in {

--- a/test/controllers/ArrivalMovementControllerSpec.scala
+++ b/test/controllers/ArrivalMovementControllerSpec.scala
@@ -397,10 +397,10 @@ class ArrivalMovementControllerSpec extends AnyFreeSpec with Matchers with Guice
  "GET /movements/arrivals/" - {
 
    "return 200 with json body of a sequence of arrivals" in {
-     when(mockArrivalConnector.getForEori()(any(), any(), any()))
+     when(mockArrivalConnector.getForEori(any())(any(), any(), any()))
        .thenReturn(Future.successful(Right(Arrivals(Seq(sourceArrival, sourceArrival, sourceArrival)))))
 
-     val request = FakeRequest("GET", routes.ArrivalMovementController.getArrivalsForEori.url, headers = FakeHeaders(Seq(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")), AnyContentAsEmpty)
+     val request = FakeRequest("GET", routes.ArrivalMovementController.getArrivalsForEori(None).url, headers = FakeHeaders(Seq(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")), AnyContentAsEmpty)
      val result = route(app, request).value
 
      val expectedJson = Json.parse(
@@ -467,10 +467,10 @@ class ArrivalMovementControllerSpec extends AnyFreeSpec with Matchers with Guice
    }
 
    "return 200 with empty list if that is provided" in {
-     when(mockArrivalConnector.getForEori()(any(), any(), any()))
+     when(mockArrivalConnector.getForEori(any())(any(), any(), any()))
        .thenReturn(Future.successful(Right(Arrivals(Nil))))
 
-     val request = FakeRequest("GET", routes.ArrivalMovementController.getArrivalsForEori.url, headers = FakeHeaders(Seq(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")), AnyContentAsEmpty)
+     val request = FakeRequest("GET", routes.ArrivalMovementController.getArrivalsForEori(None).url, headers = FakeHeaders(Seq(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")), AnyContentAsEmpty)
      val result = route(app, request).value
 
      val expectedJson = Json.parse(
@@ -491,10 +491,10 @@ class ArrivalMovementControllerSpec extends AnyFreeSpec with Matchers with Guice
    }
 
    "return 500 for downstream errors" in {
-     when(mockArrivalConnector.getForEori()(any(), any(), any()))
+     when(mockArrivalConnector.getForEori(any())(any(), any(), any()))
        .thenReturn(Future.successful(Left(HttpResponse(INTERNAL_SERVER_ERROR, ""))))
 
-     val request = FakeRequest("GET", routes.ArrivalMovementController.getArrivalsForEori.url, headers = FakeHeaders(Seq(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")), AnyContentAsEmpty)
+     val request = FakeRequest("GET", routes.ArrivalMovementController.getArrivalsForEori(None).url, headers = FakeHeaders(Seq(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")), AnyContentAsEmpty)
      val result = route(app, request).value
 
      status(result) mustBe INTERNAL_SERVER_ERROR

--- a/test/controllers/ArrivalMovementControllerSpec.scala
+++ b/test/controllers/ArrivalMovementControllerSpec.scala
@@ -500,7 +500,7 @@ class ArrivalMovementControllerSpec extends AnyFreeSpec with Matchers with Guice
      contentAsString(result) mustEqual expectedJson.toString()
    }
 
-   "pass updated_since parameter on to connector" in {
+   "pass updatedSince parameter on to connector" in {
     val argCaptor = ArgumentCaptor.forClass(classOf[Option[OffsetDateTime]])
     val dateTime = Some(OffsetDateTime.of(2021, 6, 23, 12, 1, 24, 0, ZoneOffset.UTC))
 


### PR DESCRIPTION
This adds an optional `updatedSince` query parameter to the "Get all Movement Arrivals" endpoint. This will allow API users to cut down the amount of data they need to fetch at one time.