### PR TITLE
CTDA-1294 Filter messages by received timestamp

### DIFF
--- a/app/connectors/ArrivalMessageConnector.scala
+++ b/app/connectors/ArrivalMessageConnector.scala
@@ -28,6 +28,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.HttpClient
 import uk.gov.hmrc.http.HttpResponse
 
+import java.time.OffsetDateTime
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -58,12 +59,14 @@ class ArrivalMessageConnector @Inject() (http: HttpClient, appConfig: AppConfig,
     }
 
   def getMessages(
-    arrivalId: String
+    arrivalId: String,
+    receivedSince: Option[OffsetDateTime]
   )(implicit requestHeader: RequestHeader, hc: HeaderCarrier, ec: ExecutionContext): Future[Either[HttpResponse, ArrivalWithMessages]] =
     withMetricsTimerAsync(GetMessagesForArrival) {
       timer =>
         val url = appConfig.traderAtDestinationUrl.withPath(arrivalRoute).addPathParts(arrivalId, "messages")
-        http.GET[HttpResponse](url.toString, queryParams = Seq(), responseHeaders)(CustomHttpReader, enforceAuthHeaderCarrier(responseHeaders), ec).map {
+        val query = receivedSince.map(dt => Seq("receivedSince" -> queryDateFormatter.format(dt))).getOrElse(Seq.empty)
+        http.GET[HttpResponse](url.toString, queryParams = query, responseHeaders)(CustomHttpReader, enforceAuthHeaderCarrier(responseHeaders), ec).map {
           response =>
             if (is2xx(response.status)) timer.completeWithSuccess() else timer.completeWithFailure()
             extractIfSuccessful[ArrivalWithMessages](response)

--- a/app/controllers/ArrivalMessagesController.scala
+++ b/app/controllers/ArrivalMessagesController.scala
@@ -16,14 +16,13 @@
 
 package controllers
 
-import javax.inject.Inject
-
 import com.kenshoo.play.metrics.Metrics
 import connectors.ArrivalMessageConnector
 import controllers.actions.AuthAction
 import controllers.actions.ValidateAcceptJsonHeaderAction
 import controllers.actions.ValidateArrivalMessageAction
-import metrics.{HasActionMetrics, MetricsKeys}
+import metrics.HasActionMetrics
+import metrics.MetricsKeys
 import models.MessageType
 import models.response.HateaosArrivalMessagesPostResponseMessage
 import models.response.HateaosArrivalResponseMessage
@@ -38,6 +37,8 @@ import utils.CallOps._
 import utils.ResponseHelper
 import utils.Utils
 
+import java.time.OffsetDateTime
+import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 import scala.xml.NodeSeq
 
@@ -106,11 +107,11 @@ class ArrivalMessagesController @Inject() (
       }
     }
 
-  def getArrivalMessages(arrivalId: String): Action[AnyContent] =
+  def getArrivalMessages(arrivalId: String, receivedSince: Option[OffsetDateTime]): Action[AnyContent] =
     withMetricsTimerAction(GetArrivalMessages) {
       (authAction andThen validateAcceptJsonHeaderAction).async {
         implicit request =>
-          messageConnector.getMessages(arrivalId).map {
+          messageConnector.getMessages(arrivalId, receivedSince).map {
             case Right(a) =>
               messagesCount.update(a.messages.length)
               Ok(Json.toJson(HateaosResponseArrivalWithMessages(a)))

--- a/app/controllers/DepartureMessagesController.scala
+++ b/app/controllers/DepartureMessagesController.scala
@@ -16,14 +16,13 @@
 
 package controllers
 
-import javax.inject.Inject
-
 import com.kenshoo.play.metrics.Metrics
 import connectors.DepartureMessageConnector
 import controllers.actions.AuthAction
 import controllers.actions.ValidateAcceptJsonHeaderAction
 import controllers.actions.ValidateDepartureMessageAction
-import metrics.{HasActionMetrics, MetricsKeys}
+import metrics.HasActionMetrics
+import metrics.MetricsKeys
 import models.MessageType
 import models.response.HateaosDepartureMessagesPostResponseMessage
 import models.response.HateaosDepartureResponseMessage
@@ -38,6 +37,8 @@ import utils.CallOps._
 import utils.ResponseHelper
 import utils.Utils
 
+import java.time.OffsetDateTime
+import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 import scala.xml.NodeSeq
 
@@ -93,11 +94,11 @@ class DepartureMessagesController @Inject() (
       }
     }
 
-  def getDepartureMessages(departureId: String): Action[AnyContent] =
+  def getDepartureMessages(departureId: String, receivedSince: Option[OffsetDateTime]): Action[AnyContent] =
     withMetricsTimerAction(GetDepartureMessages) {
       (authAction andThen validateAcceptJsonHeaderAction).async {
         implicit request =>
-          messageConnector.getMessages(departureId).map {
+          messageConnector.getMessages(departureId, receivedSince).map {
             case Right(d) =>
               messagesCount.update(d.messages.length)
               Ok(Json.toJson(HateaosResponseDepartureWithMessages(d)))

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -5,7 +5,7 @@ PUT        /movements/arrivals/:arrivalId                           controllers.
 GET        /movements/arrivals/:arrivalId                           controllers.ArrivalMovementController.getArrival(arrivalId: String)
 
 POST       /movements/arrivals/:arrivalId/messages                  controllers.ArrivalMessagesController.sendMessageDownstream(arrivalId: String)
-GET        /movements/arrivals/:arrivalId/messages                  controllers.ArrivalMessagesController.getArrivalMessages(arrivalId: String)
+GET        /movements/arrivals/:arrivalId/messages                  controllers.ArrivalMessagesController.getArrivalMessages(arrivalId: String, receivedSince: Option[OffsetDateTime] ?= None)
 
 GET        /movements/arrivals/:arrivalId/messages/:messageId       controllers.ArrivalMessagesController.getArrivalMessage(arrivalId: String, messageId: String)
 
@@ -17,6 +17,6 @@ POST       /movements/departures                                    controllers.
 GET        /movements/departures/:departureId                       controllers.DeparturesController.getDeparture(departureId: String)
 
 POST       /movements/departures/:departureId/messages              controllers.DepartureMessagesController.sendMessageDownstream(departureId: String)
-GET        /movements/departures/:departureId/messages              controllers.DepartureMessagesController.getDepartureMessages(departureId: String)
+GET        /movements/departures/:departureId/messages              controllers.DepartureMessagesController.getDepartureMessages(departureId: String, receivedSince: Option[OffsetDateTime] ?= None)
 
 GET        /movements/departures/:departureId/messages/:messageId   controllers.DepartureMessagesController.getDepartureMessage(departureId: String, messageId: String)

--- a/it/connectors/ArrivalMessageConnectorSpec.scala
+++ b/it/connectors/ArrivalMessageConnectorSpec.scala
@@ -32,6 +32,8 @@ import uk.gov.hmrc.http.HeaderCarrier
 import utils.CallOps._
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 
 class ArrivalMessageConnectorSpec extends AnyFreeSpec with Matchers with WiremockSuite with ScalaFutures with IntegrationPatience with ScalaCheckPropertyChecks {
 
@@ -140,7 +142,30 @@ class ArrivalMessageConnectorSpec extends AnyFreeSpec with Matchers with Wiremoc
       implicit val hc = HeaderCarrier()
       implicit val requestHeader = FakeRequest()
 
-      val result = connector.getMessages("1").futureValue
+      val result = connector.getMessages("1", receivedSince = None).futureValue
+
+      result mustEqual Right(arrival)
+    }
+
+    "must render receivedSince parameter into request URL" in {
+      val connector = app.injector.instanceOf[ArrivalMessageConnector]
+      val dateTime = Some(OffsetDateTime.of(2021, 3, 14, 13, 15, 30, 0, ZoneOffset.ofHours(1)))
+      val arrival = ArrivalWithMessages(1, routes.ArrivalMovementController.getArrival("1").urlWithContext, routes.ArrivalMessagesController.getArrivalMessages("1").urlWithContext, "MRN", "status", LocalDateTime.now, LocalDateTime.now,
+        Seq(
+          MovementMessage(routes.ArrivalMessagesController.getArrivalMessage("1","1").urlWithContext, LocalDateTime.now, "abc", <test>default</test>),
+          MovementMessage(routes.ArrivalMessagesController.getArrivalMessage("1","2").urlWithContext, LocalDateTime.now, "abc", <test>default</test>)
+        ))
+
+      server.stubFor(
+        get(
+          urlEqualTo("/transit-movements-trader-at-destination/movements/arrivals/1/messages?receivedSince=2021-03-14T13%3A15%3A30%2B01%3A00")
+        ).willReturn(aResponse().withStatus(OK)
+          .withBody(Json.toJson(arrival).toString())))
+
+      implicit val hc = HeaderCarrier()
+      implicit val requestHeader = FakeRequest()
+
+      val result = connector.getMessages("1", receivedSince = dateTime).futureValue
 
       result mustEqual Right(arrival)
     }
@@ -159,7 +184,7 @@ class ArrivalMessageConnectorSpec extends AnyFreeSpec with Matchers with Wiremoc
       implicit val hc = HeaderCarrier()
       implicit val requestHeader = FakeRequest()
 
-      val result = connector.getMessages("1").futureValue
+      val result = connector.getMessages("1", receivedSince = None).futureValue
 
       result.isLeft mustEqual true
       result.left.map { x => x.status mustEqual INTERNAL_SERVER_ERROR }
@@ -175,7 +200,7 @@ class ArrivalMessageConnectorSpec extends AnyFreeSpec with Matchers with Wiremoc
       implicit val hc = HeaderCarrier()
       implicit val requestHeader = FakeRequest()
 
-      val result = connector.getMessages("1").futureValue
+      val result = connector.getMessages("1", receivedSince = None).futureValue
 
       result.isLeft mustEqual true
       result.left.map { x => x.status mustEqual NOT_FOUND }
@@ -191,7 +216,7 @@ class ArrivalMessageConnectorSpec extends AnyFreeSpec with Matchers with Wiremoc
       implicit val hc = HeaderCarrier()
       implicit val requestHeader = FakeRequest()
 
-      val result = connector.getMessages("1").futureValue
+      val result = connector.getMessages("1", receivedSince = None).futureValue
 
       result.isLeft mustEqual true
       result.left.map { x => x.status mustEqual BAD_REQUEST }
@@ -207,7 +232,7 @@ class ArrivalMessageConnectorSpec extends AnyFreeSpec with Matchers with Wiremoc
       implicit val hc = HeaderCarrier()
       implicit val requestHeader = FakeRequest()
 
-      val result = connector.getMessages("1").futureValue
+      val result = connector.getMessages("1", receivedSince = None).futureValue
 
       result.isLeft mustEqual true
       result.left.map { x => x.status mustEqual INTERNAL_SERVER_ERROR }

--- a/resources/public/api/conf/1.0/application.raml
+++ b/resources/public/api/conf/1.0/application.raml
@@ -246,10 +246,18 @@ traits:
           description: |
             Get all the messages to do with a Movement Arrival. Any Movement Arrivals more than 28 days old will have been archived along with their related messages. Archived movements will return an HTTP 404 Not Found status.
 
+            You may opt to filter this list of messages so that you only receive messages that have been received since a specified date and time.
+
             You will only be able to retrieve these messages if you have the correct Economic Operator Registration and Identification (EORI) number for that Movement Arrival.
           is:
             - headers.acceptHeader
             - acceptHeaderInvalid
+          queryParameters:
+            receivedSince:
+              required: false
+              type: datetime
+              description: This is an optional filtering parameter. It allows you to request only the messages relating to a Movement Arrival which have been received since the date and time you have given us.
+              example: 2021-06-21T09:00+00:00
           (annotations.scope): "common-transit-convention-traders"
           securedBy: [ sec.oauth_2_0: { scopes: [ "common-transit-convention-traders" ] } ]
           responses:
@@ -507,12 +515,20 @@ traits:
           description: |
             Get all messages sent within 28 days of the goods being released relating to a Movement Departure. Any Movements that are more than 28 days old will have been archived. Archived notifications will be return an HTTP 404 Not Found status.
 
+            You may opt to filter this list of messages so that you only receive messages that have been received since a specified date and time.
+
             You will only be able to retrieve these messages if you have the EORI number associated with the Movement Departure.
 
             **Note**: The 'movementReferenceNumber' field will only be populated when an MRN is allocated.
           is:
             - headers.acceptHeader
             - acceptHeaderInvalid
+          queryParameters:
+            receivedSince:
+              required: false
+              type: datetime
+              description: This is an optional filtering parameter. It allows you to request only the messages relating to a Movement Departure which have been received since the date and time you have given us.
+              example: 2021-06-21T09:00+00:00
           (annotations.scope): "common-transit-convention-traders"
           securedBy: [ sec.oauth_2_0: { scopes: [ "common-transit-convention-traders" ] } ]
           responses:


### PR DESCRIPTION
Allows users to filter the GET all messages endpoint by received datetime of the message.