### PR TITLE
CTDA-1600 Revert GET /box endpoint as the prod config can't be merged

### DIFF
--- a/resources/public/api/conf/1.0/application.raml
+++ b/resources/public/api/conf/1.0/application.raml
@@ -643,28 +643,28 @@ traits:
                       }
               404:
                 description: When message does not exist, has been archived or is not available to the EORI number.
-  /push-pull-notifications/box:
-    get:
-      displayName: Get Box Info
-      description: |
-        Get Box Information for the application if there is a push-pull-notification box
-      is:
-        - headers.acceptHeader
-        - acceptHeaderInvalid
-      (annotations.scope): "common-transit-convention-traders"
-      securedBy: [ sec.x-application ]
-      responses:
-        200:
-          body:
-            application/json:
-              description: JSON Payload
-              example: |
-                {
-                    "boxId": "5fb4b568-b5ff-4475-bd29-0a3e70abb6d6",
-                    "boxName": "customs/transits##1.0##notificationUrl",
-                    "_links": {
-                        "self": {
-                            "href": "/customs/transits/movements/push-pull-notifications/box"
-                        }
-                    }
-                }
+  # /push-pull-notifications/box:
+  #   get:
+  #     displayName: Get Box Info
+  #     description: |
+  #       Get Box Information for the application if there is a push-pull-notification box
+  #     is:
+  #       - headers.acceptHeader
+  #       - acceptHeaderInvalid
+  #     (annotations.scope): "common-transit-convention-traders"
+  #     securedBy: [ sec.x-application ]
+  #     responses:
+  #       200:
+  #         body:
+  #           application/json:
+  #             description: JSON Payload
+  #             example: |
+  #               {
+  #                   "boxId": "5fb4b568-b5ff-4475-bd29-0a3e70abb6d6",
+  #                   "boxName": "customs/transits##1.0##notificationUrl",
+  #                   "_links": {
+  #                       "self": {
+  #                           "href": "/customs/transits/movements/push-pull-notifications/box"
+  #                       }
+  #                   }
+  #               }


### PR DESCRIPTION
The prod configuration PRs for this endpoint were never merged and we are in a change freeze. This will not work in prod if it's deployed now.