### PR TITLE
CTDA-1861 Alternative: Reject messages with namespaces on root tag 

### DIFF
--- a/app/connectors/PushPullNotificationConnector.scala
+++ b/app/connectors/PushPullNotificationConnector.scala
@@ -17,14 +17,18 @@
 package connectors
 
 import com.google.inject.Inject
-import config.{AppConfig, Constants}
+import config.AppConfig
+import config.Constants
 import models.Box
 import uk.gov.hmrc.http.HttpReads.Implicits._
-import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, UpstreamErrorResponse}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.HttpClient
+import uk.gov.hmrc.http.UpstreamErrorResponse
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 
-class PushPullNotificationConnector @Inject()(config: AppConfig, http: HttpClient) {
+class PushPullNotificationConnector @Inject() (config: AppConfig, http: HttpClient) {
 
   def getBox(clientId: String)(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[Either[UpstreamErrorResponse, Box]] = {
     val url = s"${config.pushPullUrl}/box"

--- a/app/connectors/util/CustomHttpReader.scala
+++ b/app/connectors/util/CustomHttpReader.scala
@@ -18,7 +18,9 @@ package connectors.util
 
 import play.api.Logging
 import play.api.http.Status
-import uk.gov.hmrc.http.{HttpErrorFunctions, HttpReads, HttpResponse}
+import uk.gov.hmrc.http.HttpErrorFunctions
+import uk.gov.hmrc.http.HttpReads
+import uk.gov.hmrc.http.HttpResponse
 
 object CustomHttpReader extends HttpReads[HttpResponse] with HttpErrorFunctions with Status with Logging {
 

--- a/app/controllers/PushPullNotificationController.scala
+++ b/app/controllers/PushPullNotificationController.scala
@@ -19,36 +19,40 @@ package controllers
 import config.Constants
 import connectors.PushPullNotificationConnector
 import javax.inject.Inject
-import models.response.{JsonClientErrorResponse, JsonSystemErrorResponse}
+import models.response.JsonClientErrorResponse
+import models.response.JsonSystemErrorResponse
 import play.api.libs.json.Json
-import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.ControllerComponents
 import uk.gov.hmrc.http.HttpErrorFunctions
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import utils.ResponseHelper
 import models.response.HateoasResponseBox
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 
-class PushPullNotificationController @Inject() (cc: ControllerComponents,
-                                                pushPullNotificationConnector: PushPullNotificationConnector)
-                                               (implicit ec: ExecutionContext)
-  extends BackendController(cc)
+class PushPullNotificationController @Inject() (cc: ControllerComponents, pushPullNotificationConnector: PushPullNotificationConnector)(implicit
+  ec: ExecutionContext
+) extends BackendController(cc)
     with HttpErrorFunctions
     with ResponseHelper {
 
   def getBoxInfo(): Action[AnyContent] = Action.async {
-    implicit request => {
+    implicit request =>
       request.headers.get(Constants.XClientIdHeader) match {
-        case Some(clientId) => pushPullNotificationConnector.getBox(clientId).map {
-          response =>
-          response match {
-            case Left(error) if(error.statusCode == NOT_FOUND) => NotFound(Json.toJson(JsonClientErrorResponse(NOT_FOUND, "No box found for your client id")))
-            case Left(_) => InternalServerError(Json.toJson(JsonSystemErrorResponse(INTERNAL_SERVER_ERROR, "Unexpected Error")))
-            case Right(box) => Ok(Json.toJson(HateoasResponseBox(box)))
+        case Some(clientId) =>
+          pushPullNotificationConnector.getBox(clientId).map {
+            response =>
+              response match {
+                case Left(error) if error.statusCode == NOT_FOUND =>
+                  NotFound(Json.toJson(JsonClientErrorResponse(NOT_FOUND, "No box found for your client id")))
+                case Left(_)    => InternalServerError(Json.toJson(JsonSystemErrorResponse(INTERNAL_SERVER_ERROR, "Unexpected Error")))
+                case Right(box) => Ok(Json.toJson(HateoasResponseBox(box)))
+              }
           }
-        }
-        case None =>  Future.successful(BadRequest(Json.toJson(JsonClientErrorResponse(BAD_REQUEST, "Client Id Required"))))
+        case None => Future.successful(BadRequest(Json.toJson(JsonClientErrorResponse(BAD_REQUEST, "Client Id Required"))))
       }
-    }
   }
 }

--- a/app/controllers/actions/ValidateArrivalMessageAction.scala
+++ b/app/controllers/actions/ValidateArrivalMessageAction.scala
@@ -40,7 +40,7 @@ class ValidateArrivalMessageAction @Inject() (xmlValidationService: XmlValidatio
           val rootElementName = body.head.label
           XSDFile.Arrival.SupportedMessages.get(rootElementName) match {
             case Some(xsd) =>
-              xmlValidationService.validate(body.toString, xsd) match {
+              xmlValidationService.validate(body, xsd) match {
                 case Right(_) =>
                   Future.successful(Right(request))
                 case Left(error: XmlError) =>

--- a/app/controllers/actions/ValidateArrivalNotificationAction.scala
+++ b/app/controllers/actions/ValidateArrivalNotificationAction.scala
@@ -36,7 +36,7 @@ class ValidateArrivalNotificationAction @Inject() (xmlValidationService: XmlVali
     request.body match {
       case body: NodeSeq =>
         if (body.nonEmpty) {
-          xmlValidationService.validate(body.toString, ArrivalNotificationXSD) match {
+          xmlValidationService.validate(body, ArrivalNotificationXSD) match {
             case Right(_) =>
               Future.successful(Right(request))
             case Left(error: XmlError) =>

--- a/app/controllers/actions/ValidateDepartureDeclarationAction.scala
+++ b/app/controllers/actions/ValidateDepartureDeclarationAction.scala
@@ -36,7 +36,7 @@ class ValidateDepartureDeclarationAction @Inject() (xmlValidationService: XmlVal
     request.body match {
       case body: NodeSeq =>
         if (body.nonEmpty) {
-          xmlValidationService.validate(body.toString, DepartureDeclarationXSD) match {
+          xmlValidationService.validate(body, DepartureDeclarationXSD) match {
             case Right(_) =>
               Future.successful(Right(request))
             case Left(error: XmlError) =>

--- a/app/controllers/actions/ValidateDepartureMessageAction.scala
+++ b/app/controllers/actions/ValidateDepartureMessageAction.scala
@@ -40,7 +40,7 @@ class ValidateDepartureMessageAction @Inject() (xmlValidationService: XmlValidat
           val rootElementName = body.head.label
           XSDFile.Departure.SupportedMessages.get(rootElementName) match {
             case Some(xsd) =>
-              xmlValidationService.validate(body.toString, xsd) match {
+              xmlValidationService.validate(body, xsd) match {
                 case Right(_) =>
                   Future.successful(Right(request))
                 case Left(error: XmlError) =>

--- a/app/models/response/HateoasResponseBox.scala
+++ b/app/models/response/HateoasResponseBox.scala
@@ -18,7 +18,8 @@ package models.response
 
 import controllers.routes
 import models.Box
-import play.api.libs.json.{JsObject, Json}
+import play.api.libs.json.JsObject
+import play.api.libs.json.Json
 import utils.CallOps._
 
 object HateoasResponseBox {
@@ -27,13 +28,13 @@ object HateoasResponseBox {
 
     val boxUrl = routes.PushPullNotificationController.getBoxInfo().urlWithContext
 
-      Json
-        .obj(
-          "boxId"                      -> box.boxId,
-          "boxName"                 -> box.boxName,
-          "_links" -> Json.obj(
-            "self"     -> Json.obj("href" -> boxUrl),
-          )
+    Json
+      .obj(
+        "boxId"   -> box.boxId,
+        "boxName" -> box.boxName,
+        "_links" -> Json.obj(
+          "self" -> Json.obj("href" -> boxUrl)
         )
+      )
   }
 }

--- a/app/utils/JsonHelper.scala
+++ b/app/utils/JsonHelper.scala
@@ -18,10 +18,13 @@ package utils
 
 import org.json.XML
 import play.api.Logging
-import play.api.libs.json.{JsObject, Json}
+import play.api.libs.json.JsObject
+import play.api.libs.json.Json
 
 import javax.inject.Inject
-import scala.util.{Failure, Success, Try}
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
 import scala.xml.NodeSeq
 
 class JsonHelper @Inject() (messageTranslation: MessageTranslation) extends Logging {

--- a/app/utils/ResponseHelper.scala
+++ b/app/utils/ResponseHelper.scala
@@ -20,8 +20,11 @@ import models.response.JsonClientErrorResponse
 import play.api.Logging
 import play.api.http.Status
 import play.api.libs.json.Json
-import play.api.mvc.{Result, Results}
-import uk.gov.hmrc.http.{HttpErrorFunctions, HttpResponse, UpstreamErrorResponse}
+import play.api.mvc.Result
+import play.api.mvc.Results
+import uk.gov.hmrc.http.HttpErrorFunctions
+import uk.gov.hmrc.http.HttpResponse
+import uk.gov.hmrc.http.UpstreamErrorResponse
 
 trait ResponseHelper extends Results with Status with HttpErrorFunctions with Logging {
 

--- a/it/connectors/PushPullNotificationConnectorSpec.scala
+++ b/it/connectors/PushPullNotificationConnectorSpec.scala
@@ -18,8 +18,10 @@ package connectors
 
 import com.github.tomakehurst.wiremock.client.WireMock._
 import config.Constants
-import models.{Box, BoxId}
-import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import models.Box
+import models.BoxId
+import org.scalatest.concurrent.IntegrationPatience
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import play.api.test.Helpers._

--- a/it/services/EnsureGuaranteeServiceIntegrationSpec.scala
+++ b/it/services/EnsureGuaranteeServiceIntegrationSpec.scala
@@ -57,7 +57,7 @@ class EnsureGuaranteeServiceIntegrationSpec
       "result must pass standard validation" in {
         val result = service.ensureGuarantee(TestData.buildGBEUXml(TestData.standardInputXML))
 
-        validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+        validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
       "result must not be changed if no standard guarantees" in {
         val result = service.ensureGuarantee(TestData.buildGBEUXml(TestData.otherInputXML))
@@ -68,26 +68,26 @@ class EnsureGuaranteeServiceIntegrationSpec
         val result = service.ensureGuarantee(TestData.buildGBEUXml(TestData.extraGuaranteesInputXML))
 
         normalise(result.right.get) mustEqual normalise(TestData.buildGBEUXml(TestData.extraGuaranteesExpectedXML))
-        validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+        validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
       "must add default special mentions to first good if special mention isn't present for a guarantee" in {
         val result = service.ensureGuarantee(TestData.buildGBEUXml(TestData.extraGuaranteesComboInputXML))
 
         normalise(result.right.get) mustEqual normalise(TestData.buildGBEUXml(TestData.extraGuaranteesComboExpectedXML))
-        validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+        validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
       "must allow non-guarantee special mentions through without issue" in {
         val result = service.ensureGuarantee(TestData.buildGBEUXml(TestData.oddSpecialMentionsInputXml))
 
         result.right.get.toString().filter(_ > ' ') mustEqual TestData.buildGBEUXml(TestData.oddSpecialMentionsOutputXml).toString().filter(_ > ' ')
-        validator.validate(result.right.get.toString().filter(_ > ' '), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+        validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
 
       }
       "must allow CAL special mentions with additional values through without removing fields" in {
         val result = service.ensureGuarantee(TestData.buildGBEUXml(TestData.mixedSpecialMentionsInputXml))
 
         normalise(result.right.get) mustEqual normalise(TestData.buildGBEUXml(TestData.mixedSpecialMentionsOutputXml))
-        validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+        validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
     }
   }
@@ -110,7 +110,7 @@ class EnsureGuaranteeServiceIntegrationSpec
       val expectedXml = TestData.buildGBEUXml(TestData.basicGuarantee ++ TestData.goodsWithCustomSpecialMention(customSpecialMention ++ addedSpecialMention))
       val result      = service.ensureGuarantee(xml)
       normalise(result.right.get) mustEqual normalise(expectedXml)
-      validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+      validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
     }
 
     "GB -> EU, type 1, non-CAL Special Mentions - SM Passes through to core unedited, new one added" in {
@@ -123,7 +123,7 @@ class EnsureGuaranteeServiceIntegrationSpec
       val xml       = TestData.buildGBEUXml(insertXml)
       val result    = service.ensureGuarantee(xml)
       normalise(result.right.get) mustEqual normalise(xml)
-      validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+      validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
     }
 
     "GB -> EU, with Reference Type, Has Reference Number, CAL Special Mentions, Currency & Value > 0.01 - should pass through unedited" in {
@@ -133,7 +133,7 @@ class EnsureGuaranteeServiceIntegrationSpec
           val xml       = TestData.buildGBEUXml(insertXml)
           val result    = service.ensureGuarantee(xml)
           normalise(result.right.get) mustEqual normalise(xml)
-          validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+          validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
     }
 
@@ -145,7 +145,7 @@ class EnsureGuaranteeServiceIntegrationSpec
           val expectedXml = TestData.buildGBEUXml(TestData.guaranteeWithType(typeNum) ++ TestData.goodsWithCustomSpecialMention(addedSpecialMention))
           val result      = service.ensureGuarantee(xml)
           normalise(result.right.get) mustEqual normalise(expectedXml)
-          validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+          validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
     }
 
@@ -162,7 +162,7 @@ class EnsureGuaranteeServiceIntegrationSpec
           val expectedXml = TestData.buildGBEUXml(TestData.guaranteeWithType(typeNum) ++ TestData.goodsWithCustomSpecialMention(custom ++ addedSpecialMention))
           val result      = service.ensureGuarantee(xml)
           normalise(result.right.get) mustEqual normalise(expectedXml)
-          validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+          validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
     }
 
@@ -173,7 +173,7 @@ class EnsureGuaranteeServiceIntegrationSpec
           val xml       = TestData.buildGBGBXml(insertXml)
           val result    = service.ensureGuarantee(xml)
           normalise(result.right.get) mustEqual normalise(xml)
-          validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+          validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
     }
 
@@ -184,7 +184,7 @@ class EnsureGuaranteeServiceIntegrationSpec
           val xml       = TestData.buildGBGBXml(insertXml)
           val result    = service.ensureGuarantee(xml)
           normalise(result.right.get) mustEqual normalise(xml)
-          validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+          validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
     }
 
@@ -200,7 +200,7 @@ class EnsureGuaranteeServiceIntegrationSpec
           val xml       = TestData.buildGBGBXml(insertXml)
           val result    = service.ensureGuarantee(xml)
           normalise(result.right.get) mustEqual normalise(xml)
-          validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+          validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
     }
 
@@ -229,7 +229,7 @@ class EnsureGuaranteeServiceIntegrationSpec
           )
           val result = service.ensureGuarantee(xml)
           normalise(result.right.get) mustEqual normalise(expectedXml)
-          validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+          validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
     }
 
@@ -243,7 +243,7 @@ class EnsureGuaranteeServiceIntegrationSpec
       val expectedXml = TestData.buildGBXIXml(TestData.basicGuarantee ++ TestData.goodsWithCustomSpecialMention(custom ++ addedSpecialMention))
       val result      = service.ensureGuarantee(xml)
       normalise(result.right.get) mustEqual normalise(expectedXml)
-      validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+      validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
     }
 
     "GB -> XI, type 1, non-CAL Special Mentions - SM Passes through to core unedited" in {
@@ -256,7 +256,7 @@ class EnsureGuaranteeServiceIntegrationSpec
       val xml       = TestData.buildGBXIXml(insertXml)
       val result    = service.ensureGuarantee(xml)
       normalise(result.right.get) mustEqual normalise(xml)
-      validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+      validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
     }
 
   }

--- a/it/utils/WiremockSuite.scala
+++ b/it/utils/WiremockSuite.scala
@@ -40,13 +40,13 @@ trait WiremockSuite extends BeforeAndAfterAll with BeforeAndAfterEach with Guice
 
   lazy val applicationBuilder: GuiceApplicationBuilder =
     new GuiceApplicationBuilder()
-    .configure(
-      portConfigKey.map {
-        key =>
-          key -> server.port.toString()
-      }: _*
-    )
-    .overrides(bindings: _*)
+      .configure(
+        portConfigKey.map {
+          key =>
+            key -> server.port.toString()
+        }: _*
+      )
+      .overrides(bindings: _*)
 
   override lazy val fakeApplication: Application =
     applicationBuilder.build()

--- a/test/connectors/BaseConnectorSpec.scala
+++ b/test/connectors/BaseConnectorSpec.scala
@@ -82,7 +82,7 @@ class BaseConnectorSpec extends AnyFreeSpec with Matchers {
               HeaderNames.ACCEPT        -> ContentTypes.JSON,
               HeaderNames.CONTENT_TYPE  -> ContentTypes.XML,
               Constants.ChannelHeader   -> "api",
-              Constants.XClientIdHeader  -> "foo"
+              Constants.XClientIdHeader -> "foo"
             )
           )
         }
@@ -150,7 +150,7 @@ class BaseConnectorSpec extends AnyFreeSpec with Matchers {
             HeaderNames.AUTHORIZATION -> "",
             HeaderNames.ACCEPT        -> ContentTypes.JSON,
             Constants.ChannelHeader   -> "api",
-            Constants.XClientIdHeader  -> "foo"
+            Constants.XClientIdHeader -> "foo"
           ))
         }
 

--- a/test/controllers/PushPullNotificationControllerSpec.scala
+++ b/test/controllers/PushPullNotificationControllerSpec.scala
@@ -19,16 +19,20 @@ package controllers
 import com.kenshoo.play.metrics.Metrics
 import config.Constants
 import connectors.PushPullNotificationConnector
-import controllers.actions.{AuthAction, FakeAuthAction}
+import controllers.actions.AuthAction
+import controllers.actions.FakeAuthAction
 import data.TestXml
 import models.response.HateoasResponseBox
-import models.{Box, BoxId}
+import models.Box
+import models.BoxId
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{reset, when}
+import org.mockito.Mockito.reset
+import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
-import org.scalatest.{BeforeAndAfterEach, OptionValues}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.OptionValues
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.http.HeaderNames
@@ -37,14 +41,15 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.Json
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.Helpers._
-import play.api.test.{FakeHeaders, FakeRequest}
+import play.api.test.FakeHeaders
+import play.api.test.FakeRequest
 import uk.gov.hmrc.http.UpstreamErrorResponse
 import utils.TestMetrics
 
 import scala.concurrent.Future
 
 class PushPullNotificationControllerSpec
-  extends AnyFreeSpec
+    extends AnyFreeSpec
     with Matchers
     with GuiceOneAppPerSuite
     with OptionValues
@@ -78,10 +83,12 @@ class PushPullNotificationControllerSpec
       when(mockPushPullNotificationConnector.getBox(any())(any(), any()))
         .thenReturn(Future.successful(Right(box)))
 
-      val request = FakeRequest("GET",
+      val request = FakeRequest(
+        "GET",
         routes.PushPullNotificationController.getBoxInfo().url,
         headers = FakeHeaders(Seq(Constants.XClientIdHeader -> "foo", HeaderNames.ACCEPT -> "application/vnd.hrmc.1.0+json")),
-        AnyContentAsEmpty)
+        AnyContentAsEmpty
+      )
 
       val result = route(app, request).value
 
@@ -94,10 +101,12 @@ class PushPullNotificationControllerSpec
       when(mockPushPullNotificationConnector.getBox(any())(any(), any()))
         .thenReturn(Future.successful(Left(UpstreamErrorResponse("", NOT_FOUND))))
 
-      val request = FakeRequest("GET",
+      val request = FakeRequest(
+        "GET",
         routes.PushPullNotificationController.getBoxInfo().url,
         headers = FakeHeaders(Seq(Constants.XClientIdHeader -> "foo", HeaderNames.ACCEPT -> "application/vnd.hrmc.1.0+json")),
-        AnyContentAsEmpty)
+        AnyContentAsEmpty
+      )
 
       val result = route(app, request).value
 
@@ -108,10 +117,12 @@ class PushPullNotificationControllerSpec
       when(mockPushPullNotificationConnector.getBox(any())(any(), any()))
         .thenReturn(Future.successful(Left(UpstreamErrorResponse("", INTERNAL_SERVER_ERROR))))
 
-      val request = FakeRequest("GET",
+      val request = FakeRequest(
+        "GET",
         routes.PushPullNotificationController.getBoxInfo().url,
         headers = FakeHeaders(Seq(Constants.XClientIdHeader -> "foo", HeaderNames.ACCEPT -> "application/vnd.hrmc.1.0+json")),
-        AnyContentAsEmpty)
+        AnyContentAsEmpty
+      )
 
       val result = route(app, request).value
 
@@ -119,10 +130,12 @@ class PushPullNotificationControllerSpec
     }
 
     "returns BadRequest if ClientId not found" in {
-      val request = FakeRequest("GET",
+      val request = FakeRequest(
+        "GET",
         routes.PushPullNotificationController.getBoxInfo().url,
         headers = FakeHeaders(Seq(HeaderNames.ACCEPT -> "application/vnd.hrmc.1.0+json")),
-        AnyContentAsEmpty)
+        AnyContentAsEmpty
+      )
 
       val result = route(app, request).value
 

--- a/test/models/response/HateoasResponseBoxSpec.scala
+++ b/test/models/response/HateoasResponseBoxSpec.scala
@@ -16,11 +16,13 @@
 
 package models.response
 
-import models.{Box, BoxId}
+import models.Box
+import models.BoxId
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
-import org.scalatest.{BeforeAndAfterEach, OptionValues}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.OptionValues
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.libs.json.Json

--- a/test/services/XmlValidationServiceSpec.scala
+++ b/test/services/XmlValidationServiceSpec.scala
@@ -26,6 +26,9 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
+import scala.xml.NodeSeq
+import scala.xml.XML
+
 class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks {
 
   private val xmlValidationService = new XmlValidationService
@@ -37,7 +40,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
       "with minimal completed fields" in {
         val xml = buildIE007Xml()
 
-        xmlValidationService.validate(xml, ArrivalNotificationXSD) mustBe a[Right[_, _]]
+        xmlValidationService.validate(XML.loadString(xml), ArrivalNotificationXSD) mustBe a[Right[_, _]]
       }
 
       "with an enroute event" in {
@@ -45,7 +48,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
         forAll(arbitrary[Boolean], arbitrary[Boolean], arbitrary[Boolean], arbitrary[Boolean]) {
           (withIncident, withContainer, withVehicle, withSeals) =>
             val xml = buildIE007Xml(withEnrouteEvent = true, withIncident, withContainer, withVehicle, withSeals)
-            xmlValidationService.validate(xml, ArrivalNotificationXSD) mustBe a[Right[_, _]]
+            xmlValidationService.validate(XML.loadString(xml), ArrivalNotificationXSD) mustBe a[Right[_, _]]
         }
       }
     }
@@ -55,7 +58,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
       "with minimal completed fields" in {
         val xml = buildIE015Xml()
 
-        xmlValidationService.validate(xml, DepartureDeclarationXSD) mustBe a[Right[_, _]]
+        xmlValidationService.validate(XML.loadString(xml), DepartureDeclarationXSD) mustBe a[Right[_, _]]
       }
 
     }
@@ -69,28 +72,28 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
           v =>
             val xml = buildIE015Xml(withMessageType = s"${v}015B")
 
-            xmlValidationService.validate(xml, DepartureDeclarationXSD) mustBe Right(XmlSuccessfullyValidated)
+            xmlValidationService.validate(XML.loadString(xml), DepartureDeclarationXSD) mustBe Right(XmlSuccessfullyValidated)
         }
 
         "for CC007A" in prefixes.foreach {
           v =>
             val xml = buildIE007Xml(withMessageType = s"${v}007A")
 
-            xmlValidationService.validate(xml, ArrivalNotificationXSD) mustBe Right(XmlSuccessfullyValidated)
+            xmlValidationService.validate(XML.loadString(xml), ArrivalNotificationXSD) mustBe Right(XmlSuccessfullyValidated)
         }
 
         "for CC044A" in prefixes.foreach {
           v =>
             val xml = buildIE044Xml(withMessageType = s"${v}044A")
 
-            xmlValidationService.validate(xml, UnloadingRemarksXSD) mustBe Right(XmlSuccessfullyValidated)
+            xmlValidationService.validate(XML.loadString(xml), UnloadingRemarksXSD) mustBe Right(XmlSuccessfullyValidated)
         }
 
         "for CC014A" in prefixes.foreach {
           v =>
             val xml = buildIE014Xml(withMessageType = s"${v}014A")
 
-            xmlValidationService.validate(xml, DeclarationCancellationRequestXSD) mustBe Right(XmlSuccessfullyValidated)
+            xmlValidationService.validate(XML.loadString(xml), DeclarationCancellationRequestXSD) mustBe Right(XmlSuccessfullyValidated)
         }
       }
 
@@ -110,7 +113,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
             val expectedMessage =
               s"The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc015b.xsd'. Detailed error below:\ncvc-pattern-valid: Value '$v' is not facet-valid with respect to pattern '(CC|GB|XI)015B' for type 'CC015B_MessageType'."
 
-            xmlValidationService.validate(xml, DepartureDeclarationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+            xmlValidationService.validate(XML.loadString(xml), DepartureDeclarationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
         }
 
         "for CC007A" in forResult("007A").foreach {
@@ -120,7 +123,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
             val expectedMessage =
               s"The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc007a.xsd'. Detailed error below:\ncvc-pattern-valid: Value '$v' is not facet-valid with respect to pattern '(CC|GB|XI)007A' for type 'CC007A_MessageType'."
 
-            xmlValidationService.validate(xml, ArrivalNotificationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+            xmlValidationService.validate(XML.loadString(xml), ArrivalNotificationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
         }
 
         "for CC044A" in forResult("044A").foreach {
@@ -130,7 +133,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
             val expectedMessage =
               s"The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc044a.xsd'. Detailed error below:\ncvc-pattern-valid: Value '$v' is not facet-valid with respect to pattern '(CC|GB|XI)044A' for type 'CC044A_MessageType'."
 
-            xmlValidationService.validate(xml, UnloadingRemarksXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+            xmlValidationService.validate(XML.loadString(xml), UnloadingRemarksXSD) mustBe Left(FailedToValidateXml(expectedMessage))
         }
 
         "for CC014A" in forResult("014A").foreach {
@@ -140,7 +143,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
             val expectedMessage =
               s"The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc014a.xsd'. Detailed error below:\ncvc-pattern-valid: Value '$v' is not facet-valid with respect to pattern '(CC|GB|XI)014A' for type 'CC014A_MessageType'."
 
-            xmlValidationService.validate(xml, DeclarationCancellationRequestXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+            xmlValidationService.validate(XML.loadString(xml), DeclarationCancellationRequestXSD) mustBe Left(FailedToValidateXml(expectedMessage))
         }
 
       }
@@ -155,7 +158,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
             val expectedMessage =
               s"The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc015b.xsd'. Detailed error below:\ncvc-pattern-valid: Value '$v' is not facet-valid with respect to pattern '(CC|GB|XI)015B' for type 'CC015B_MessageType'."
 
-            xmlValidationService.validate(xml, DepartureDeclarationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+            xmlValidationService.validate(XML.loadString(xml), DepartureDeclarationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
         }
 
         "for CC007A" in values.foreach {
@@ -165,7 +168,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
             val expectedMessage =
               s"The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc007a.xsd'. Detailed error below:\ncvc-pattern-valid: Value '$v' is not facet-valid with respect to pattern '(CC|GB|XI)007A' for type 'CC007A_MessageType'."
 
-            xmlValidationService.validate(xml, ArrivalNotificationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+            xmlValidationService.validate(XML.loadString(xml), ArrivalNotificationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
         }
 
         "for CC044A" in values.foreach {
@@ -175,7 +178,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
             val expectedMessage =
               s"The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc044a.xsd'. Detailed error below:\ncvc-pattern-valid: Value '$v' is not facet-valid with respect to pattern '(CC|GB|XI)044A' for type 'CC044A_MessageType'."
 
-            xmlValidationService.validate(xml, UnloadingRemarksXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+            xmlValidationService.validate(XML.loadString(xml), UnloadingRemarksXSD) mustBe Left(FailedToValidateXml(expectedMessage))
         }
 
         "for CC014A" in values.foreach {
@@ -185,7 +188,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
             val expectedMessage =
               s"The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc014a.xsd'. Detailed error below:\ncvc-pattern-valid: Value '$v' is not facet-valid with respect to pattern '(CC|GB|XI)014A' for type 'CC014A_MessageType'."
 
-            xmlValidationService.validate(xml, DeclarationCancellationRequestXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+            xmlValidationService.validate(XML.loadString(xml), DeclarationCancellationRequestXSD) mustBe Left(FailedToValidateXml(expectedMessage))
         }
 
       }
@@ -194,7 +197,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
     "must fail when validating an invalid DepartureDeclaration xml" - {
 
       "with missing mandatory elements" in {
-        val xml = "<CC015B></CC015B>"
+        val xml = <CC015B></CC015B>
 
         val expectedMessage =
           "The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc015b.xsd'. Detailed error below:\ncvc-complex-type.2.4.b: The content of element 'CC015B' is not complete. One of '{SynIdeMES1}' is expected."
@@ -204,17 +207,19 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
 
       "with invalid fields" in {
 
-        val xml =
-          """
-            |<CC015B>
-            |    <SynIdeMES1>11111111111111</SynIdeMES1>
-            |</CC015B>
-          """.stripMargin
+        val xml = <CC015B><SynIdeMES1>11111111111111</SynIdeMES1></CC015B>
 
         val expectedMessage =
           "The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc015b.xsd'. Detailed error below:\ncvc-pattern-valid: Value '11111111111111' is not facet-valid with respect to pattern '[a-zA-Z]{4}' for type 'Alpha_4'."
 
         xmlValidationService.validate(xml, DepartureDeclarationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+      }
+
+      "with an empty body" in {
+
+        val expectedMessage = "The request cannot be processed as it does not contain a request body."
+
+        xmlValidationService.validate(NodeSeq.Empty, DepartureDeclarationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
       }
     }
 
@@ -226,7 +231,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
         val expectedMessage =
           "The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc007a.xsd'. Detailed error below:\ncvc-complex-type.2.4.b: The content of element 'CC007A' is not complete. One of '{SynIdeMES1}' is expected."
 
-        xmlValidationService.validate(xml, ArrivalNotificationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+        xmlValidationService.validate(XML.loadString(xml), ArrivalNotificationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
       }
 
       "with invalid fields" in {
@@ -241,7 +246,25 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
         val expectedMessage =
           "The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc007a.xsd'. Detailed error below:\ncvc-pattern-valid: Value '11111111111111' is not facet-valid with respect to pattern '[a-zA-Z]{4}' for type 'Alpha_4'."
 
+        xmlValidationService.validate(XML.loadString(xml), ArrivalNotificationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+      }
+
+      "with an empty body" in {
+
+        val expectedMessage = "The request cannot be processed as it does not contain a request body."
+
+        xmlValidationService.validate(NodeSeq.Empty, ArrivalNotificationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+      }
+
+      "with an unexpected namespace" in {
+
+        val xml = XML.loadString(buildIE007Xml(with2001Namespace = true))
+
+        val expectedMessage =
+          "The request cannot be processed as it contains a namespace on the root node. Please remove any \"xmlns:\" attributes from all nodes."
+
         xmlValidationService.validate(xml, ArrivalNotificationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+
       }
     }
   }
@@ -252,7 +275,8 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
     withContainerTranshipment: Boolean = false,
     withVehicularTranshipment: Boolean = false,
     withSeals: Boolean = false,
-    withMessageType: String = "GB007A"
+    withMessageType: String = "GB007A",
+    with2001Namespace: Boolean = false
   ): String = {
 
     val enrouteEvent = {
@@ -261,8 +285,12 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
       else ""
     }
 
+    val namespace =
+      if (with2001Namespace) "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\""
+      else ""
+
     s"""
-       |<CC007A>
+       |<CC007A $namespace>
        |    <SynIdeMES1>UNOC</SynIdeMES1>
        |    <SynVerNumMES2>3</SynVerNumMES2>
        |    <MesRecMES6>NCTS</MesRecMES6>

--- a/test/services/XmlValidationServiceSpec.scala
+++ b/test/services/XmlValidationServiceSpec.scala
@@ -96,7 +96,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
 
       "with a Message Type that doesn't match the message" - {
         val prefixes: List[String] = List("CC", "GB", "XI")
-        val values: List[String] = List("015B", "007A", "014A", "044A")
+        val values: List[String]   = List("015B", "007A", "014A", "044A")
 
         def forResult(code: String): List[String] = for {
           p <- prefixes

--- a/test/xml/CC007ASpec.scala
+++ b/test/xml/CC007ASpec.scala
@@ -30,15 +30,15 @@ class CC007ASpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks
   "validate" - {
 
     "must be successful when validating a valid CC007A xml" in {
-      xmlValidationService.validate(CC007A.toString(), ArrivalNotificationXSD) mustBe a[Right[_, _]]
+      xmlValidationService.validate(CC007A, ArrivalNotificationXSD) mustBe a[Right[_, _]]
     }
 
     "must fail when validating an invalid CC007A xml" in {
-      xmlValidationService.validate(InvalidCC007A.toString(), ArrivalNotificationXSD) mustBe a[Left[_, _]]
+      xmlValidationService.validate(InvalidCC007A, ArrivalNotificationXSD) mustBe a[Left[_, _]]
     }
 
     "must reject a CC007A containing MesSenMES3" in {
-      xmlValidationService.validate(CC007AwithMesSenMES3.toString(), ArrivalNotificationXSD) mustBe a[Left[_, _]]
+      xmlValidationService.validate(CC007AwithMesSenMES3, ArrivalNotificationXSD) mustBe a[Left[_, _]]
     }
   }
 }

--- a/test/xml/CC014ASpec.scala
+++ b/test/xml/CC014ASpec.scala
@@ -30,15 +30,15 @@ class CC014ASpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks
   "validate" - {
 
     "must be successful when validating a valid CC014A xml" in {
-      xmlValidationService.validate(CC014A.toString(), DeclarationCancellationRequestXSD) mustBe a[Right[_, _]]
+      xmlValidationService.validate(CC014A, DeclarationCancellationRequestXSD) mustBe a[Right[_, _]]
     }
 
     "must fail when validating an invalid CC014A xml" in {
-      xmlValidationService.validate(InvalidCC014A.toString(), DeclarationCancellationRequestXSD) mustBe a[Left[_, _]]
+      xmlValidationService.validate(InvalidCC014A, DeclarationCancellationRequestXSD) mustBe a[Left[_, _]]
     }
 
     "must reject a CC014A containing MesSenMES3" in {
-      xmlValidationService.validate(CC014AwithMesSenMES3.toString(), DeclarationCancellationRequestXSD) mustBe a[Left[_, _]]
+      xmlValidationService.validate(CC014AwithMesSenMES3, DeclarationCancellationRequestXSD) mustBe a[Left[_, _]]
     }
   }
 }

--- a/test/xml/CC015BSpec.scala
+++ b/test/xml/CC015BSpec.scala
@@ -30,15 +30,15 @@ class CC015BSpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks
   "validate" - {
 
     "must be successful when validating a valid CC015B xml" in {
-      xmlValidationService.validate(CC015B.toString(), DepartureDeclarationXSD) mustBe a[Right[_, _]]
+      xmlValidationService.validate(CC015B, DepartureDeclarationXSD) mustBe a[Right[_, _]]
     }
 
     "must fail when validating an invalid CC015B xml" in {
-      xmlValidationService.validate(InvalidCC015B.toString(), DepartureDeclarationXSD) mustBe a[Left[_, _]]
+      xmlValidationService.validate(InvalidCC015B, DepartureDeclarationXSD) mustBe a[Left[_, _]]
     }
 
     "must reject a CC015B containing MesSenMES3" in {
-      xmlValidationService.validate(CC015BwithMesSenMES3.toString(), DepartureDeclarationXSD) mustBe a[Left[_, _]]
+      xmlValidationService.validate(CC015BwithMesSenMES3, DepartureDeclarationXSD) mustBe a[Left[_, _]]
     }
   }
 }

--- a/test/xml/CC044ASpec.scala
+++ b/test/xml/CC044ASpec.scala
@@ -30,15 +30,15 @@ class CC044ASpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks
   "validate" - {
 
     "must be successful when validating a valid CC044A xml" in {
-      xmlValidationService.validate(CC044A.toString(), UnloadingRemarksXSD) mustBe a[Right[_, _]]
+      xmlValidationService.validate(CC044A, UnloadingRemarksXSD) mustBe a[Right[_, _]]
     }
 
     "must fail when validating an invalid CC044A xml" in {
-      xmlValidationService.validate(InvalidCC044A.toString(), UnloadingRemarksXSD) mustBe a[Left[_, _]]
+      xmlValidationService.validate(InvalidCC044A, UnloadingRemarksXSD) mustBe a[Left[_, _]]
     }
 
     "must reject a CC044A containing MesSenMES3" in {
-      xmlValidationService.validate(CC044AwithMesSenMES3.toString(), UnloadingRemarksXSD) mustBe a[Left[_, _]]
+      xmlValidationService.validate(CC044AwithMesSenMES3, UnloadingRemarksXSD) mustBe a[Left[_, _]]
     }
   }
 }


### PR DESCRIPTION
This is an alternative to #236 - if this is merged, that shouldn't be (and vice versa).

Still need to get data on which route to take, but wanted to show this could be done.

Scalafmt was run first, so you're most likely to be interested in the second commit for the actual changes.