### PR TITLE
CLI-156: Revert "CTDA-1861: Reject messages with a namespace on the root node"

### DIFF
--- a/app/controllers/actions/ValidateArrivalMessageAction.scala
+++ b/app/controllers/actions/ValidateArrivalMessageAction.scala
@@ -40,7 +40,7 @@ class ValidateArrivalMessageAction @Inject() (xmlValidationService: XmlValidatio
           val rootElementName = body.head.label
           XSDFile.Arrival.SupportedMessages.get(rootElementName) match {
             case Some(xsd) =>
-              xmlValidationService.validate(body, xsd) match {
+              xmlValidationService.validate(body.toString, xsd) match {
                 case Right(_) =>
                   Future.successful(Right(request))
                 case Left(error: XmlError) =>

--- a/app/controllers/actions/ValidateArrivalNotificationAction.scala
+++ b/app/controllers/actions/ValidateArrivalNotificationAction.scala
@@ -36,7 +36,7 @@ class ValidateArrivalNotificationAction @Inject() (xmlValidationService: XmlVali
     request.body match {
       case body: NodeSeq =>
         if (body.nonEmpty) {
-          xmlValidationService.validate(body, ArrivalNotificationXSD) match {
+          xmlValidationService.validate(body.toString, ArrivalNotificationXSD) match {
             case Right(_) =>
               Future.successful(Right(request))
             case Left(error: XmlError) =>

--- a/app/controllers/actions/ValidateDepartureDeclarationAction.scala
+++ b/app/controllers/actions/ValidateDepartureDeclarationAction.scala
@@ -36,7 +36,7 @@ class ValidateDepartureDeclarationAction @Inject() (xmlValidationService: XmlVal
     request.body match {
       case body: NodeSeq =>
         if (body.nonEmpty) {
-          xmlValidationService.validate(body, DepartureDeclarationXSD) match {
+          xmlValidationService.validate(body.toString, DepartureDeclarationXSD) match {
             case Right(_) =>
               Future.successful(Right(request))
             case Left(error: XmlError) =>

--- a/app/controllers/actions/ValidateDepartureMessageAction.scala
+++ b/app/controllers/actions/ValidateDepartureMessageAction.scala
@@ -40,7 +40,7 @@ class ValidateDepartureMessageAction @Inject() (xmlValidationService: XmlValidat
           val rootElementName = body.head.label
           XSDFile.Departure.SupportedMessages.get(rootElementName) match {
             case Some(xsd) =>
-              xmlValidationService.validate(body, xsd) match {
+              xmlValidationService.validate(body.toString, xsd) match {
                 case Right(_) =>
                   Future.successful(Right(request))
                 case Left(error: XmlError) =>

--- a/app/services/XmlValidationService.scala
+++ b/app/services/XmlValidationService.scala
@@ -18,6 +18,7 @@ package services
 
 import java.io._
 import java.net.URL
+
 import javax.xml.parsers.SAXParserFactory
 import javax.xml.validation.Schema
 import models.request.XSDFile
@@ -28,10 +29,8 @@ import utils.Utils
 
 import scala.xml.factory.XMLLoader
 import scala.xml.Elem
-import scala.xml.NodeSeq
 import scala.xml.SAXParseException
 import scala.xml.SAXParser
-import scala.xml.TopScope
 
 class XmlValidationService {
 
@@ -50,14 +49,7 @@ class XmlValidationService {
     saxParser.newSAXParser()
   }
 
-  def validate(xml: NodeSeq, xsdFile: XSDFile): Either[XmlError, XmlValid] =
-    xml.headOption match {
-      case Some(x) if x.scope == TopScope => validate(x.toString, xsdFile)
-      case Some(_)                        => Left(FailedToValidateXml(XmlError.RequestBodyRootContainsNamespaceMessage))
-      case None                           => Left(FailedToValidateXml(XmlError.RequestBodyEmptyMessage))
-    }
-
-  private def validate(xml: String, xsdFile: XSDFile): Either[XmlError, XmlValid] =
+  def validate(xml: String, xsdFile: XSDFile): Either[XmlError, XmlValid] =
     try {
 
       val url: URL = getClass.getResource(xsdFile.FilePath)
@@ -106,9 +98,6 @@ object XmlError {
   val RequestBodyEmptyMessage = "The request cannot be processed as it does not contain a request body."
 
   val RequestBodyInvalidTypeMessage = "The request cannot be processed as it does not contain an XML request body."
-
-  val RequestBodyRootContainsNamespaceMessage =
-    "The request cannot be processed as it contains a namespace on the root node. Please remove any \"xmlns:\" attributes from all nodes."
 }
 
 case class FailedToValidateXml(reason: String) extends XmlError

--- a/it/services/EnsureGuaranteeServiceIntegrationSpec.scala
+++ b/it/services/EnsureGuaranteeServiceIntegrationSpec.scala
@@ -57,7 +57,7 @@ class EnsureGuaranteeServiceIntegrationSpec
       "result must pass standard validation" in {
         val result = service.ensureGuarantee(TestData.buildGBEUXml(TestData.standardInputXML))
 
-        validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+        validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
       "result must not be changed if no standard guarantees" in {
         val result = service.ensureGuarantee(TestData.buildGBEUXml(TestData.otherInputXML))
@@ -68,26 +68,26 @@ class EnsureGuaranteeServiceIntegrationSpec
         val result = service.ensureGuarantee(TestData.buildGBEUXml(TestData.extraGuaranteesInputXML))
 
         normalise(result.right.get) mustEqual normalise(TestData.buildGBEUXml(TestData.extraGuaranteesExpectedXML))
-        validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+        validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
       "must add default special mentions to first good if special mention isn't present for a guarantee" in {
         val result = service.ensureGuarantee(TestData.buildGBEUXml(TestData.extraGuaranteesComboInputXML))
 
         normalise(result.right.get) mustEqual normalise(TestData.buildGBEUXml(TestData.extraGuaranteesComboExpectedXML))
-        validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+        validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
       "must allow non-guarantee special mentions through without issue" in {
         val result = service.ensureGuarantee(TestData.buildGBEUXml(TestData.oddSpecialMentionsInputXml))
 
         result.right.get.toString().filter(_ > ' ') mustEqual TestData.buildGBEUXml(TestData.oddSpecialMentionsOutputXml).toString().filter(_ > ' ')
-        validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+        validator.validate(result.right.get.toString().filter(_ > ' '), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
 
       }
       "must allow CAL special mentions with additional values through without removing fields" in {
         val result = service.ensureGuarantee(TestData.buildGBEUXml(TestData.mixedSpecialMentionsInputXml))
 
         normalise(result.right.get) mustEqual normalise(TestData.buildGBEUXml(TestData.mixedSpecialMentionsOutputXml))
-        validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+        validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
     }
   }
@@ -110,7 +110,7 @@ class EnsureGuaranteeServiceIntegrationSpec
       val expectedXml = TestData.buildGBEUXml(TestData.basicGuarantee ++ TestData.goodsWithCustomSpecialMention(customSpecialMention ++ addedSpecialMention))
       val result      = service.ensureGuarantee(xml)
       normalise(result.right.get) mustEqual normalise(expectedXml)
-      validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+      validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
     }
 
     "GB -> EU, type 1, non-CAL Special Mentions - SM Passes through to core unedited, new one added" in {
@@ -123,7 +123,7 @@ class EnsureGuaranteeServiceIntegrationSpec
       val xml       = TestData.buildGBEUXml(insertXml)
       val result    = service.ensureGuarantee(xml)
       normalise(result.right.get) mustEqual normalise(xml)
-      validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+      validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
     }
 
     "GB -> EU, with Reference Type, Has Reference Number, CAL Special Mentions, Currency & Value > 0.01 - should pass through unedited" in {
@@ -133,7 +133,7 @@ class EnsureGuaranteeServiceIntegrationSpec
           val xml       = TestData.buildGBEUXml(insertXml)
           val result    = service.ensureGuarantee(xml)
           normalise(result.right.get) mustEqual normalise(xml)
-          validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+          validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
     }
 
@@ -145,7 +145,7 @@ class EnsureGuaranteeServiceIntegrationSpec
           val expectedXml = TestData.buildGBEUXml(TestData.guaranteeWithType(typeNum) ++ TestData.goodsWithCustomSpecialMention(addedSpecialMention))
           val result      = service.ensureGuarantee(xml)
           normalise(result.right.get) mustEqual normalise(expectedXml)
-          validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+          validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
     }
 
@@ -162,7 +162,7 @@ class EnsureGuaranteeServiceIntegrationSpec
           val expectedXml = TestData.buildGBEUXml(TestData.guaranteeWithType(typeNum) ++ TestData.goodsWithCustomSpecialMention(custom ++ addedSpecialMention))
           val result      = service.ensureGuarantee(xml)
           normalise(result.right.get) mustEqual normalise(expectedXml)
-          validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+          validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
     }
 
@@ -173,7 +173,7 @@ class EnsureGuaranteeServiceIntegrationSpec
           val xml       = TestData.buildGBGBXml(insertXml)
           val result    = service.ensureGuarantee(xml)
           normalise(result.right.get) mustEqual normalise(xml)
-          validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+          validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
     }
 
@@ -184,7 +184,7 @@ class EnsureGuaranteeServiceIntegrationSpec
           val xml       = TestData.buildGBGBXml(insertXml)
           val result    = service.ensureGuarantee(xml)
           normalise(result.right.get) mustEqual normalise(xml)
-          validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+          validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
     }
 
@@ -200,7 +200,7 @@ class EnsureGuaranteeServiceIntegrationSpec
           val xml       = TestData.buildGBGBXml(insertXml)
           val result    = service.ensureGuarantee(xml)
           normalise(result.right.get) mustEqual normalise(xml)
-          validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+          validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
     }
 
@@ -229,7 +229,7 @@ class EnsureGuaranteeServiceIntegrationSpec
           )
           val result = service.ensureGuarantee(xml)
           normalise(result.right.get) mustEqual normalise(expectedXml)
-          validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+          validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
     }
 
@@ -243,7 +243,7 @@ class EnsureGuaranteeServiceIntegrationSpec
       val expectedXml = TestData.buildGBXIXml(TestData.basicGuarantee ++ TestData.goodsWithCustomSpecialMention(custom ++ addedSpecialMention))
       val result      = service.ensureGuarantee(xml)
       normalise(result.right.get) mustEqual normalise(expectedXml)
-      validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+      validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
     }
 
     "GB -> XI, type 1, non-CAL Special Mentions - SM Passes through to core unedited" in {
@@ -256,7 +256,7 @@ class EnsureGuaranteeServiceIntegrationSpec
       val xml       = TestData.buildGBXIXml(insertXml)
       val result    = service.ensureGuarantee(xml)
       normalise(result.right.get) mustEqual normalise(xml)
-      validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+      validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
     }
 
   }

--- a/test/services/XmlValidationServiceSpec.scala
+++ b/test/services/XmlValidationServiceSpec.scala
@@ -26,9 +26,6 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-import scala.xml.NodeSeq
-import scala.xml.XML
-
 class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks {
 
   private val xmlValidationService = new XmlValidationService
@@ -40,7 +37,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
       "with minimal completed fields" in {
         val xml = buildIE007Xml()
 
-        xmlValidationService.validate(XML.loadString(xml), ArrivalNotificationXSD) mustBe a[Right[_, _]]
+        xmlValidationService.validate(xml, ArrivalNotificationXSD) mustBe a[Right[_, _]]
       }
 
       "with an enroute event" in {
@@ -48,7 +45,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
         forAll(arbitrary[Boolean], arbitrary[Boolean], arbitrary[Boolean], arbitrary[Boolean]) {
           (withIncident, withContainer, withVehicle, withSeals) =>
             val xml = buildIE007Xml(withEnrouteEvent = true, withIncident, withContainer, withVehicle, withSeals)
-            xmlValidationService.validate(XML.loadString(xml), ArrivalNotificationXSD) mustBe a[Right[_, _]]
+            xmlValidationService.validate(xml, ArrivalNotificationXSD) mustBe a[Right[_, _]]
         }
       }
     }
@@ -58,7 +55,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
       "with minimal completed fields" in {
         val xml = buildIE015Xml()
 
-        xmlValidationService.validate(XML.loadString(xml), DepartureDeclarationXSD) mustBe a[Right[_, _]]
+        xmlValidationService.validate(xml, DepartureDeclarationXSD) mustBe a[Right[_, _]]
       }
 
     }
@@ -72,28 +69,28 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
           v =>
             val xml = buildIE015Xml(withMessageType = s"${v}015B")
 
-            xmlValidationService.validate(XML.loadString(xml), DepartureDeclarationXSD) mustBe Right(XmlSuccessfullyValidated)
+            xmlValidationService.validate(xml, DepartureDeclarationXSD) mustBe Right(XmlSuccessfullyValidated)
         }
 
         "for CC007A" in prefixes.foreach {
           v =>
             val xml = buildIE007Xml(withMessageType = s"${v}007A")
 
-            xmlValidationService.validate(XML.loadString(xml), ArrivalNotificationXSD) mustBe Right(XmlSuccessfullyValidated)
+            xmlValidationService.validate(xml, ArrivalNotificationXSD) mustBe Right(XmlSuccessfullyValidated)
         }
 
         "for CC044A" in prefixes.foreach {
           v =>
             val xml = buildIE044Xml(withMessageType = s"${v}044A")
 
-            xmlValidationService.validate(XML.loadString(xml), UnloadingRemarksXSD) mustBe Right(XmlSuccessfullyValidated)
+            xmlValidationService.validate(xml, UnloadingRemarksXSD) mustBe Right(XmlSuccessfullyValidated)
         }
 
         "for CC014A" in prefixes.foreach {
           v =>
             val xml = buildIE014Xml(withMessageType = s"${v}014A")
 
-            xmlValidationService.validate(XML.loadString(xml), DeclarationCancellationRequestXSD) mustBe Right(XmlSuccessfullyValidated)
+            xmlValidationService.validate(xml, DeclarationCancellationRequestXSD) mustBe Right(XmlSuccessfullyValidated)
         }
       }
 
@@ -113,7 +110,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
             val expectedMessage =
               s"The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc015b.xsd'. Detailed error below:\ncvc-pattern-valid: Value '$v' is not facet-valid with respect to pattern '(CC|GB|XI)015B' for type 'CC015B_MessageType'."
 
-            xmlValidationService.validate(XML.loadString(xml), DepartureDeclarationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+            xmlValidationService.validate(xml, DepartureDeclarationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
         }
 
         "for CC007A" in forResult("007A").foreach {
@@ -123,7 +120,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
             val expectedMessage =
               s"The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc007a.xsd'. Detailed error below:\ncvc-pattern-valid: Value '$v' is not facet-valid with respect to pattern '(CC|GB|XI)007A' for type 'CC007A_MessageType'."
 
-            xmlValidationService.validate(XML.loadString(xml), ArrivalNotificationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+            xmlValidationService.validate(xml, ArrivalNotificationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
         }
 
         "for CC044A" in forResult("044A").foreach {
@@ -133,7 +130,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
             val expectedMessage =
               s"The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc044a.xsd'. Detailed error below:\ncvc-pattern-valid: Value '$v' is not facet-valid with respect to pattern '(CC|GB|XI)044A' for type 'CC044A_MessageType'."
 
-            xmlValidationService.validate(XML.loadString(xml), UnloadingRemarksXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+            xmlValidationService.validate(xml, UnloadingRemarksXSD) mustBe Left(FailedToValidateXml(expectedMessage))
         }
 
         "for CC014A" in forResult("014A").foreach {
@@ -143,7 +140,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
             val expectedMessage =
               s"The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc014a.xsd'. Detailed error below:\ncvc-pattern-valid: Value '$v' is not facet-valid with respect to pattern '(CC|GB|XI)014A' for type 'CC014A_MessageType'."
 
-            xmlValidationService.validate(XML.loadString(xml), DeclarationCancellationRequestXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+            xmlValidationService.validate(xml, DeclarationCancellationRequestXSD) mustBe Left(FailedToValidateXml(expectedMessage))
         }
 
       }
@@ -158,7 +155,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
             val expectedMessage =
               s"The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc015b.xsd'. Detailed error below:\ncvc-pattern-valid: Value '$v' is not facet-valid with respect to pattern '(CC|GB|XI)015B' for type 'CC015B_MessageType'."
 
-            xmlValidationService.validate(XML.loadString(xml), DepartureDeclarationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+            xmlValidationService.validate(xml, DepartureDeclarationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
         }
 
         "for CC007A" in values.foreach {
@@ -168,7 +165,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
             val expectedMessage =
               s"The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc007a.xsd'. Detailed error below:\ncvc-pattern-valid: Value '$v' is not facet-valid with respect to pattern '(CC|GB|XI)007A' for type 'CC007A_MessageType'."
 
-            xmlValidationService.validate(XML.loadString(xml), ArrivalNotificationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+            xmlValidationService.validate(xml, ArrivalNotificationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
         }
 
         "for CC044A" in values.foreach {
@@ -178,7 +175,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
             val expectedMessage =
               s"The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc044a.xsd'. Detailed error below:\ncvc-pattern-valid: Value '$v' is not facet-valid with respect to pattern '(CC|GB|XI)044A' for type 'CC044A_MessageType'."
 
-            xmlValidationService.validate(XML.loadString(xml), UnloadingRemarksXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+            xmlValidationService.validate(xml, UnloadingRemarksXSD) mustBe Left(FailedToValidateXml(expectedMessage))
         }
 
         "for CC014A" in values.foreach {
@@ -188,7 +185,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
             val expectedMessage =
               s"The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc014a.xsd'. Detailed error below:\ncvc-pattern-valid: Value '$v' is not facet-valid with respect to pattern '(CC|GB|XI)014A' for type 'CC014A_MessageType'."
 
-            xmlValidationService.validate(XML.loadString(xml), DeclarationCancellationRequestXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+            xmlValidationService.validate(xml, DeclarationCancellationRequestXSD) mustBe Left(FailedToValidateXml(expectedMessage))
         }
 
       }
@@ -197,7 +194,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
     "must fail when validating an invalid DepartureDeclaration xml" - {
 
       "with missing mandatory elements" in {
-        val xml = <CC015B></CC015B>
+        val xml = "<CC015B></CC015B>"
 
         val expectedMessage =
           "The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc015b.xsd'. Detailed error below:\ncvc-complex-type.2.4.b: The content of element 'CC015B' is not complete. One of '{SynIdeMES1}' is expected."
@@ -207,19 +204,17 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
 
       "with invalid fields" in {
 
-        val xml = <CC015B><SynIdeMES1>11111111111111</SynIdeMES1></CC015B>
+        val xml =
+          """
+            |<CC015B>
+            |    <SynIdeMES1>11111111111111</SynIdeMES1>
+            |</CC015B>
+          """.stripMargin
 
         val expectedMessage =
           "The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc015b.xsd'. Detailed error below:\ncvc-pattern-valid: Value '11111111111111' is not facet-valid with respect to pattern '[a-zA-Z]{4}' for type 'Alpha_4'."
 
         xmlValidationService.validate(xml, DepartureDeclarationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
-      }
-
-      "with an empty body" in {
-
-        val expectedMessage = "The request cannot be processed as it does not contain a request body."
-
-        xmlValidationService.validate(NodeSeq.Empty, DepartureDeclarationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
       }
     }
 
@@ -231,7 +226,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
         val expectedMessage =
           "The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc007a.xsd'. Detailed error below:\ncvc-complex-type.2.4.b: The content of element 'CC007A' is not complete. One of '{SynIdeMES1}' is expected."
 
-        xmlValidationService.validate(XML.loadString(xml), ArrivalNotificationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+        xmlValidationService.validate(xml, ArrivalNotificationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
       }
 
       "with invalid fields" in {
@@ -246,25 +241,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
         val expectedMessage =
           "The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc007a.xsd'. Detailed error below:\ncvc-pattern-valid: Value '11111111111111' is not facet-valid with respect to pattern '[a-zA-Z]{4}' for type 'Alpha_4'."
 
-        xmlValidationService.validate(XML.loadString(xml), ArrivalNotificationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
-      }
-
-      "with an empty body" in {
-
-        val expectedMessage = "The request cannot be processed as it does not contain a request body."
-
-        xmlValidationService.validate(NodeSeq.Empty, ArrivalNotificationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
-      }
-
-      "with an unexpected namespace" in {
-
-        val xml = XML.loadString(buildIE007Xml(with2001Namespace = true))
-
-        val expectedMessage =
-          "The request cannot be processed as it contains a namespace on the root node. Please remove any \"xmlns:\" attributes from all nodes."
-
         xmlValidationService.validate(xml, ArrivalNotificationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
-
       }
     }
   }
@@ -275,8 +252,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
     withContainerTranshipment: Boolean = false,
     withVehicularTranshipment: Boolean = false,
     withSeals: Boolean = false,
-    withMessageType: String = "GB007A",
-    with2001Namespace: Boolean = false
+    withMessageType: String = "GB007A"
   ): String = {
 
     val enrouteEvent = {
@@ -285,12 +261,8 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
       else ""
     }
 
-    val namespace =
-      if (with2001Namespace) "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\""
-      else ""
-
     s"""
-       |<CC007A $namespace>
+       |<CC007A>
        |    <SynIdeMES1>UNOC</SynIdeMES1>
        |    <SynVerNumMES2>3</SynVerNumMES2>
        |    <MesRecMES6>NCTS</MesRecMES6>

--- a/test/xml/CC007ASpec.scala
+++ b/test/xml/CC007ASpec.scala
@@ -30,15 +30,15 @@ class CC007ASpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks
   "validate" - {
 
     "must be successful when validating a valid CC007A xml" in {
-      xmlValidationService.validate(CC007A, ArrivalNotificationXSD) mustBe a[Right[_, _]]
+      xmlValidationService.validate(CC007A.toString(), ArrivalNotificationXSD) mustBe a[Right[_, _]]
     }
 
     "must fail when validating an invalid CC007A xml" in {
-      xmlValidationService.validate(InvalidCC007A, ArrivalNotificationXSD) mustBe a[Left[_, _]]
+      xmlValidationService.validate(InvalidCC007A.toString(), ArrivalNotificationXSD) mustBe a[Left[_, _]]
     }
 
     "must reject a CC007A containing MesSenMES3" in {
-      xmlValidationService.validate(CC007AwithMesSenMES3, ArrivalNotificationXSD) mustBe a[Left[_, _]]
+      xmlValidationService.validate(CC007AwithMesSenMES3.toString(), ArrivalNotificationXSD) mustBe a[Left[_, _]]
     }
   }
 }

--- a/test/xml/CC014ASpec.scala
+++ b/test/xml/CC014ASpec.scala
@@ -30,15 +30,15 @@ class CC014ASpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks
   "validate" - {
 
     "must be successful when validating a valid CC014A xml" in {
-      xmlValidationService.validate(CC014A, DeclarationCancellationRequestXSD) mustBe a[Right[_, _]]
+      xmlValidationService.validate(CC014A.toString(), DeclarationCancellationRequestXSD) mustBe a[Right[_, _]]
     }
 
     "must fail when validating an invalid CC014A xml" in {
-      xmlValidationService.validate(InvalidCC014A, DeclarationCancellationRequestXSD) mustBe a[Left[_, _]]
+      xmlValidationService.validate(InvalidCC014A.toString(), DeclarationCancellationRequestXSD) mustBe a[Left[_, _]]
     }
 
     "must reject a CC014A containing MesSenMES3" in {
-      xmlValidationService.validate(CC014AwithMesSenMES3, DeclarationCancellationRequestXSD) mustBe a[Left[_, _]]
+      xmlValidationService.validate(CC014AwithMesSenMES3.toString(), DeclarationCancellationRequestXSD) mustBe a[Left[_, _]]
     }
   }
 }

--- a/test/xml/CC015BSpec.scala
+++ b/test/xml/CC015BSpec.scala
@@ -30,15 +30,15 @@ class CC015BSpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks
   "validate" - {
 
     "must be successful when validating a valid CC015B xml" in {
-      xmlValidationService.validate(CC015B, DepartureDeclarationXSD) mustBe a[Right[_, _]]
+      xmlValidationService.validate(CC015B.toString(), DepartureDeclarationXSD) mustBe a[Right[_, _]]
     }
 
     "must fail when validating an invalid CC015B xml" in {
-      xmlValidationService.validate(InvalidCC015B, DepartureDeclarationXSD) mustBe a[Left[_, _]]
+      xmlValidationService.validate(InvalidCC015B.toString(), DepartureDeclarationXSD) mustBe a[Left[_, _]]
     }
 
     "must reject a CC015B containing MesSenMES3" in {
-      xmlValidationService.validate(CC015BwithMesSenMES3, DepartureDeclarationXSD) mustBe a[Left[_, _]]
+      xmlValidationService.validate(CC015BwithMesSenMES3.toString(), DepartureDeclarationXSD) mustBe a[Left[_, _]]
     }
   }
 }

--- a/test/xml/CC044ASpec.scala
+++ b/test/xml/CC044ASpec.scala
@@ -30,15 +30,15 @@ class CC044ASpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks
   "validate" - {
 
     "must be successful when validating a valid CC044A xml" in {
-      xmlValidationService.validate(CC044A, UnloadingRemarksXSD) mustBe a[Right[_, _]]
+      xmlValidationService.validate(CC044A.toString(), UnloadingRemarksXSD) mustBe a[Right[_, _]]
     }
 
     "must fail when validating an invalid CC044A xml" in {
-      xmlValidationService.validate(InvalidCC044A, UnloadingRemarksXSD) mustBe a[Left[_, _]]
+      xmlValidationService.validate(InvalidCC044A.toString(), UnloadingRemarksXSD) mustBe a[Left[_, _]]
     }
 
     "must reject a CC044A containing MesSenMES3" in {
-      xmlValidationService.validate(CC044AwithMesSenMES3, UnloadingRemarksXSD) mustBe a[Left[_, _]]
+      xmlValidationService.validate(CC044AwithMesSenMES3.toString(), UnloadingRemarksXSD) mustBe a[Left[_, _]]
     }
   }
 }


### PR DESCRIPTION
This reverts commit 182e9bc0a9c7dde22686c2760fed729a1f3a7b76.

There were unforseen errors from traders that don't have namespaces on their XML files but have been hit by this check. Pending seeing some of these messages, we'll revert this commit so we don't impede developers.

This will need https://github.com/hmrc/common-transit-convention-traders-postman/commit/0f89d9cfdfc843c8ce9507e6211150f6a4357633 reverting too.