### PR TITLE
CLI-156: Re-introduce defensive XML measures

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -17,10 +17,11 @@
 package config
 
 import io.lemonlabs.uri.Url
-import javax.inject.Inject
-import javax.inject.Singleton
 import play.api.Configuration
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+
+import javax.inject.Inject
+import javax.inject.Singleton
 
 @Singleton
 class AppConfig @Inject() (config: Configuration, servicesConfig: ServicesConfig) {
@@ -38,4 +39,6 @@ class AppConfig @Inject() (config: Configuration, servicesConfig: ServicesConfig
   val messageTranslationFile: String = config.get[String]("message-translation-file")
 
   val pushPullUrl = Url.parse(servicesConfig.baseUrl("push-pull-notifications-api"))
+
+  val blockUnknownNamespaces: Boolean = config.get[Boolean]("xml-validation.block-unknown-namespaces")
 }

--- a/app/controllers/actions/ValidateArrivalMessageAction.scala
+++ b/app/controllers/actions/ValidateArrivalMessageAction.scala
@@ -40,7 +40,7 @@ class ValidateArrivalMessageAction @Inject() (xmlValidationService: XmlValidatio
           val rootElementName = body.head.label
           XSDFile.Arrival.SupportedMessages.get(rootElementName) match {
             case Some(xsd) =>
-              xmlValidationService.validate(body.toString, xsd) match {
+              xmlValidationService.validate(body, xsd) match {
                 case Right(_) =>
                   Future.successful(Right(request))
                 case Left(error: XmlError) =>

--- a/app/controllers/actions/ValidateArrivalNotificationAction.scala
+++ b/app/controllers/actions/ValidateArrivalNotificationAction.scala
@@ -36,7 +36,7 @@ class ValidateArrivalNotificationAction @Inject() (xmlValidationService: XmlVali
     request.body match {
       case body: NodeSeq =>
         if (body.nonEmpty) {
-          xmlValidationService.validate(body.toString, ArrivalNotificationXSD) match {
+          xmlValidationService.validate(body, ArrivalNotificationXSD) match {
             case Right(_) =>
               Future.successful(Right(request))
             case Left(error: XmlError) =>

--- a/app/controllers/actions/ValidateDepartureDeclarationAction.scala
+++ b/app/controllers/actions/ValidateDepartureDeclarationAction.scala
@@ -36,7 +36,7 @@ class ValidateDepartureDeclarationAction @Inject() (xmlValidationService: XmlVal
     request.body match {
       case body: NodeSeq =>
         if (body.nonEmpty) {
-          xmlValidationService.validate(body.toString, DepartureDeclarationXSD) match {
+          xmlValidationService.validate(body, DepartureDeclarationXSD) match {
             case Right(_) =>
               Future.successful(Right(request))
             case Left(error: XmlError) =>

--- a/app/controllers/actions/ValidateDepartureMessageAction.scala
+++ b/app/controllers/actions/ValidateDepartureMessageAction.scala
@@ -40,7 +40,7 @@ class ValidateDepartureMessageAction @Inject() (xmlValidationService: XmlValidat
           val rootElementName = body.head.label
           XSDFile.Departure.SupportedMessages.get(rootElementName) match {
             case Some(xsd) =>
-              xmlValidationService.validate(body.toString, xsd) match {
+              xmlValidationService.validate(body, xsd) match {
                 case Right(_) =>
                   Future.successful(Right(request))
                 case Left(error: XmlError) =>

--- a/app/services/XmlValidationService.scala
+++ b/app/services/XmlValidationService.scala
@@ -52,9 +52,12 @@ class XmlValidationService {
 
   def validate(xml: NodeSeq, xsdFile: XSDFile): Either[XmlError, XmlValid] =
     xml.headOption match {
-      case Some(x) if x.scope == TopScope => validate(x.toString, xsdFile)
-      case Some(_)                        => Left(FailedToValidateXml(XmlError.RequestBodyRootContainsNamespaceMessage))
-      case None                           => Left(FailedToValidateXml(XmlError.RequestBodyEmptyMessage))
+      case Some(x) if x.scope == TopScope || x.scope.uri == null => // null scope is xmlns=""
+        validate(x.toString, xsdFile)
+      case Some(x) =>
+        Left(FailedToValidateXml(XmlError.RequestBodyRootContainsNamespaceMessage))
+      case None =>
+        Left(FailedToValidateXml(XmlError.RequestBodyEmptyMessage))
     }
 
   private def validate(xml: String, xsdFile: XSDFile): Either[XmlError, XmlValid] =
@@ -108,7 +111,7 @@ object XmlError {
   val RequestBodyInvalidTypeMessage = "The request cannot be processed as it does not contain an XML request body."
 
   val RequestBodyRootContainsNamespaceMessage =
-    "The request cannot be processed as it contains a namespace on the root node. Please remove any \"xmlns:\" attributes from all nodes."
+    "The request cannot be processed as it contains a namespace on the root node. Please remove any \"xmlns\" attributes from all nodes."
 }
 
 case class FailedToValidateXml(reason: String) extends XmlError

--- a/app/services/XmlValidationService.scala
+++ b/app/services/XmlValidationService.scala
@@ -16,6 +16,9 @@
 
 package services
 
+import com.google.inject.Inject
+import config.AppConfig
+
 import java.io._
 import java.net.URL
 import javax.xml.parsers.SAXParserFactory
@@ -33,7 +36,7 @@ import scala.xml.SAXParseException
 import scala.xml.SAXParser
 import scala.xml.TopScope
 
-class XmlValidationService {
+class XmlValidationService @Inject() (appConfig: AppConfig) {
 
   private val logger     = Logger(getClass)
   private val schemaLang = javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI
@@ -52,9 +55,9 @@ class XmlValidationService {
 
   def validate(xml: NodeSeq, xsdFile: XSDFile): Either[XmlError, XmlValid] =
     xml.headOption match {
-      case Some(x) if x.scope == TopScope || x.scope.uri == null => // null scope is xmlns=""
+      case Some(x) if !appConfig.blockUnknownNamespaces || x.scope == TopScope || x.scope.uri == null => // null scope is xmlns=""
         validate(x.toString, xsdFile)
-      case Some(x) =>
+      case Some(_) =>
         Left(FailedToValidateXml(XmlError.RequestBodyRootContainsNamespaceMessage))
       case None =>
         Left(FailedToValidateXml(XmlError.RequestBodyEmptyMessage))

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -206,3 +206,5 @@ defaultGuarantee.currency = GBP
 defaultGuarantee.amount = 1.00
 
 play.http.parser.maxMemoryBuffer = 5M
+
+xml-validation.block-unknown-namespaces = true

--- a/it/services/EnsureGuaranteeServiceIntegrationSpec.scala
+++ b/it/services/EnsureGuaranteeServiceIntegrationSpec.scala
@@ -57,7 +57,7 @@ class EnsureGuaranteeServiceIntegrationSpec
       "result must pass standard validation" in {
         val result = service.ensureGuarantee(TestData.buildGBEUXml(TestData.standardInputXML))
 
-        validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+        validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
       "result must not be changed if no standard guarantees" in {
         val result = service.ensureGuarantee(TestData.buildGBEUXml(TestData.otherInputXML))
@@ -68,26 +68,26 @@ class EnsureGuaranteeServiceIntegrationSpec
         val result = service.ensureGuarantee(TestData.buildGBEUXml(TestData.extraGuaranteesInputXML))
 
         normalise(result.right.get) mustEqual normalise(TestData.buildGBEUXml(TestData.extraGuaranteesExpectedXML))
-        validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+        validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
       "must add default special mentions to first good if special mention isn't present for a guarantee" in {
         val result = service.ensureGuarantee(TestData.buildGBEUXml(TestData.extraGuaranteesComboInputXML))
 
         normalise(result.right.get) mustEqual normalise(TestData.buildGBEUXml(TestData.extraGuaranteesComboExpectedXML))
-        validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+        validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
       "must allow non-guarantee special mentions through without issue" in {
         val result = service.ensureGuarantee(TestData.buildGBEUXml(TestData.oddSpecialMentionsInputXml))
 
         result.right.get.toString().filter(_ > ' ') mustEqual TestData.buildGBEUXml(TestData.oddSpecialMentionsOutputXml).toString().filter(_ > ' ')
-        validator.validate(result.right.get.toString().filter(_ > ' '), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+        validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
 
       }
       "must allow CAL special mentions with additional values through without removing fields" in {
         val result = service.ensureGuarantee(TestData.buildGBEUXml(TestData.mixedSpecialMentionsInputXml))
 
         normalise(result.right.get) mustEqual normalise(TestData.buildGBEUXml(TestData.mixedSpecialMentionsOutputXml))
-        validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+        validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
     }
   }
@@ -110,7 +110,7 @@ class EnsureGuaranteeServiceIntegrationSpec
       val expectedXml = TestData.buildGBEUXml(TestData.basicGuarantee ++ TestData.goodsWithCustomSpecialMention(customSpecialMention ++ addedSpecialMention))
       val result      = service.ensureGuarantee(xml)
       normalise(result.right.get) mustEqual normalise(expectedXml)
-      validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+      validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
     }
 
     "GB -> EU, type 1, non-CAL Special Mentions - SM Passes through to core unedited, new one added" in {
@@ -123,7 +123,7 @@ class EnsureGuaranteeServiceIntegrationSpec
       val xml       = TestData.buildGBEUXml(insertXml)
       val result    = service.ensureGuarantee(xml)
       normalise(result.right.get) mustEqual normalise(xml)
-      validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+      validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
     }
 
     "GB -> EU, with Reference Type, Has Reference Number, CAL Special Mentions, Currency & Value > 0.01 - should pass through unedited" in {
@@ -133,7 +133,7 @@ class EnsureGuaranteeServiceIntegrationSpec
           val xml       = TestData.buildGBEUXml(insertXml)
           val result    = service.ensureGuarantee(xml)
           normalise(result.right.get) mustEqual normalise(xml)
-          validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+          validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
     }
 
@@ -145,7 +145,7 @@ class EnsureGuaranteeServiceIntegrationSpec
           val expectedXml = TestData.buildGBEUXml(TestData.guaranteeWithType(typeNum) ++ TestData.goodsWithCustomSpecialMention(addedSpecialMention))
           val result      = service.ensureGuarantee(xml)
           normalise(result.right.get) mustEqual normalise(expectedXml)
-          validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+          validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
     }
 
@@ -162,7 +162,7 @@ class EnsureGuaranteeServiceIntegrationSpec
           val expectedXml = TestData.buildGBEUXml(TestData.guaranteeWithType(typeNum) ++ TestData.goodsWithCustomSpecialMention(custom ++ addedSpecialMention))
           val result      = service.ensureGuarantee(xml)
           normalise(result.right.get) mustEqual normalise(expectedXml)
-          validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+          validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
     }
 
@@ -173,7 +173,7 @@ class EnsureGuaranteeServiceIntegrationSpec
           val xml       = TestData.buildGBGBXml(insertXml)
           val result    = service.ensureGuarantee(xml)
           normalise(result.right.get) mustEqual normalise(xml)
-          validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+          validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
     }
 
@@ -184,7 +184,7 @@ class EnsureGuaranteeServiceIntegrationSpec
           val xml       = TestData.buildGBGBXml(insertXml)
           val result    = service.ensureGuarantee(xml)
           normalise(result.right.get) mustEqual normalise(xml)
-          validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+          validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
     }
 
@@ -200,7 +200,7 @@ class EnsureGuaranteeServiceIntegrationSpec
           val xml       = TestData.buildGBGBXml(insertXml)
           val result    = service.ensureGuarantee(xml)
           normalise(result.right.get) mustEqual normalise(xml)
-          validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+          validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
     }
 
@@ -229,7 +229,7 @@ class EnsureGuaranteeServiceIntegrationSpec
           )
           val result = service.ensureGuarantee(xml)
           normalise(result.right.get) mustEqual normalise(expectedXml)
-          validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+          validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
       }
     }
 
@@ -243,7 +243,7 @@ class EnsureGuaranteeServiceIntegrationSpec
       val expectedXml = TestData.buildGBXIXml(TestData.basicGuarantee ++ TestData.goodsWithCustomSpecialMention(custom ++ addedSpecialMention))
       val result      = service.ensureGuarantee(xml)
       normalise(result.right.get) mustEqual normalise(expectedXml)
-      validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+      validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
     }
 
     "GB -> XI, type 1, non-CAL Special Mentions - SM Passes through to core unedited" in {
@@ -256,7 +256,7 @@ class EnsureGuaranteeServiceIntegrationSpec
       val xml       = TestData.buildGBXIXml(insertXml)
       val result    = service.ensureGuarantee(xml)
       normalise(result.right.get) mustEqual normalise(xml)
-      validator.validate(normalise(result.right.get), DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
+      validator.validate(result.right.get, DepartureDeclarationXSD) mustBe a[Right[_, XmlValid]]
     }
 
   }

--- a/test/services/XmlValidationServiceSpec.scala
+++ b/test/services/XmlValidationServiceSpec.scala
@@ -26,6 +26,9 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
+import scala.xml.NodeSeq
+import scala.xml.XML
+
 class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks {
 
   private val xmlValidationService = new XmlValidationService
@@ -37,7 +40,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
       "with minimal completed fields" in {
         val xml = buildIE007Xml()
 
-        xmlValidationService.validate(xml, ArrivalNotificationXSD) mustBe a[Right[_, _]]
+        xmlValidationService.validate(XML.loadString(xml), ArrivalNotificationXSD) mustBe a[Right[_, _]]
       }
 
       "with an enroute event" in {
@@ -45,7 +48,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
         forAll(arbitrary[Boolean], arbitrary[Boolean], arbitrary[Boolean], arbitrary[Boolean]) {
           (withIncident, withContainer, withVehicle, withSeals) =>
             val xml = buildIE007Xml(withEnrouteEvent = true, withIncident, withContainer, withVehicle, withSeals)
-            xmlValidationService.validate(xml, ArrivalNotificationXSD) mustBe a[Right[_, _]]
+            xmlValidationService.validate(XML.loadString(xml), ArrivalNotificationXSD) mustBe a[Right[_, _]]
         }
       }
     }
@@ -55,7 +58,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
       "with minimal completed fields" in {
         val xml = buildIE015Xml()
 
-        xmlValidationService.validate(xml, DepartureDeclarationXSD) mustBe a[Right[_, _]]
+        xmlValidationService.validate(XML.loadString(xml), DepartureDeclarationXSD) mustBe a[Right[_, _]]
       }
 
     }
@@ -69,28 +72,28 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
           v =>
             val xml = buildIE015Xml(withMessageType = s"${v}015B")
 
-            xmlValidationService.validate(xml, DepartureDeclarationXSD) mustBe Right(XmlSuccessfullyValidated)
+            xmlValidationService.validate(XML.loadString(xml), DepartureDeclarationXSD) mustBe Right(XmlSuccessfullyValidated)
         }
 
         "for CC007A" in prefixes.foreach {
           v =>
             val xml = buildIE007Xml(withMessageType = s"${v}007A")
 
-            xmlValidationService.validate(xml, ArrivalNotificationXSD) mustBe Right(XmlSuccessfullyValidated)
+            xmlValidationService.validate(XML.loadString(xml), ArrivalNotificationXSD) mustBe Right(XmlSuccessfullyValidated)
         }
 
         "for CC044A" in prefixes.foreach {
           v =>
             val xml = buildIE044Xml(withMessageType = s"${v}044A")
 
-            xmlValidationService.validate(xml, UnloadingRemarksXSD) mustBe Right(XmlSuccessfullyValidated)
+            xmlValidationService.validate(XML.loadString(xml), UnloadingRemarksXSD) mustBe Right(XmlSuccessfullyValidated)
         }
 
         "for CC014A" in prefixes.foreach {
           v =>
             val xml = buildIE014Xml(withMessageType = s"${v}014A")
 
-            xmlValidationService.validate(xml, DeclarationCancellationRequestXSD) mustBe Right(XmlSuccessfullyValidated)
+            xmlValidationService.validate(XML.loadString(xml), DeclarationCancellationRequestXSD) mustBe Right(XmlSuccessfullyValidated)
         }
       }
 
@@ -110,7 +113,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
             val expectedMessage =
               s"The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc015b.xsd'. Detailed error below:\ncvc-pattern-valid: Value '$v' is not facet-valid with respect to pattern '(CC|GB|XI)015B' for type 'CC015B_MessageType'."
 
-            xmlValidationService.validate(xml, DepartureDeclarationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+            xmlValidationService.validate(XML.loadString(xml), DepartureDeclarationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
         }
 
         "for CC007A" in forResult("007A").foreach {
@@ -120,7 +123,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
             val expectedMessage =
               s"The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc007a.xsd'. Detailed error below:\ncvc-pattern-valid: Value '$v' is not facet-valid with respect to pattern '(CC|GB|XI)007A' for type 'CC007A_MessageType'."
 
-            xmlValidationService.validate(xml, ArrivalNotificationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+            xmlValidationService.validate(XML.loadString(xml), ArrivalNotificationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
         }
 
         "for CC044A" in forResult("044A").foreach {
@@ -130,7 +133,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
             val expectedMessage =
               s"The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc044a.xsd'. Detailed error below:\ncvc-pattern-valid: Value '$v' is not facet-valid with respect to pattern '(CC|GB|XI)044A' for type 'CC044A_MessageType'."
 
-            xmlValidationService.validate(xml, UnloadingRemarksXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+            xmlValidationService.validate(XML.loadString(xml), UnloadingRemarksXSD) mustBe Left(FailedToValidateXml(expectedMessage))
         }
 
         "for CC014A" in forResult("014A").foreach {
@@ -140,7 +143,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
             val expectedMessage =
               s"The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc014a.xsd'. Detailed error below:\ncvc-pattern-valid: Value '$v' is not facet-valid with respect to pattern '(CC|GB|XI)014A' for type 'CC014A_MessageType'."
 
-            xmlValidationService.validate(xml, DeclarationCancellationRequestXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+            xmlValidationService.validate(XML.loadString(xml), DeclarationCancellationRequestXSD) mustBe Left(FailedToValidateXml(expectedMessage))
         }
 
       }
@@ -155,7 +158,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
             val expectedMessage =
               s"The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc015b.xsd'. Detailed error below:\ncvc-pattern-valid: Value '$v' is not facet-valid with respect to pattern '(CC|GB|XI)015B' for type 'CC015B_MessageType'."
 
-            xmlValidationService.validate(xml, DepartureDeclarationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+            xmlValidationService.validate(XML.loadString(xml), DepartureDeclarationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
         }
 
         "for CC007A" in values.foreach {
@@ -165,7 +168,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
             val expectedMessage =
               s"The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc007a.xsd'. Detailed error below:\ncvc-pattern-valid: Value '$v' is not facet-valid with respect to pattern '(CC|GB|XI)007A' for type 'CC007A_MessageType'."
 
-            xmlValidationService.validate(xml, ArrivalNotificationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+            xmlValidationService.validate(XML.loadString(xml), ArrivalNotificationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
         }
 
         "for CC044A" in values.foreach {
@@ -175,7 +178,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
             val expectedMessage =
               s"The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc044a.xsd'. Detailed error below:\ncvc-pattern-valid: Value '$v' is not facet-valid with respect to pattern '(CC|GB|XI)044A' for type 'CC044A_MessageType'."
 
-            xmlValidationService.validate(xml, UnloadingRemarksXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+            xmlValidationService.validate(XML.loadString(xml), UnloadingRemarksXSD) mustBe Left(FailedToValidateXml(expectedMessage))
         }
 
         "for CC014A" in values.foreach {
@@ -185,7 +188,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
             val expectedMessage =
               s"The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc014a.xsd'. Detailed error below:\ncvc-pattern-valid: Value '$v' is not facet-valid with respect to pattern '(CC|GB|XI)014A' for type 'CC014A_MessageType'."
 
-            xmlValidationService.validate(xml, DeclarationCancellationRequestXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+            xmlValidationService.validate(XML.loadString(xml), DeclarationCancellationRequestXSD) mustBe Left(FailedToValidateXml(expectedMessage))
         }
 
       }
@@ -194,7 +197,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
     "must fail when validating an invalid DepartureDeclaration xml" - {
 
       "with missing mandatory elements" in {
-        val xml = "<CC015B></CC015B>"
+        val xml = <CC015B></CC015B>
 
         val expectedMessage =
           "The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc015b.xsd'. Detailed error below:\ncvc-complex-type.2.4.b: The content of element 'CC015B' is not complete. One of '{SynIdeMES1}' is expected."
@@ -204,17 +207,19 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
 
       "with invalid fields" in {
 
-        val xml =
-          """
-            |<CC015B>
-            |    <SynIdeMES1>11111111111111</SynIdeMES1>
-            |</CC015B>
-          """.stripMargin
+        val xml = <CC015B><SynIdeMES1>11111111111111</SynIdeMES1></CC015B>
 
         val expectedMessage =
           "The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc015b.xsd'. Detailed error below:\ncvc-pattern-valid: Value '11111111111111' is not facet-valid with respect to pattern '[a-zA-Z]{4}' for type 'Alpha_4'."
 
         xmlValidationService.validate(xml, DepartureDeclarationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+      }
+
+      "with an empty body" in {
+
+        val expectedMessage = "The request cannot be processed as it does not contain a request body."
+
+        xmlValidationService.validate(NodeSeq.Empty, DepartureDeclarationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
       }
     }
 
@@ -226,7 +231,7 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
         val expectedMessage =
           "The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc007a.xsd'. Detailed error below:\ncvc-complex-type.2.4.b: The content of element 'CC007A' is not complete. One of '{SynIdeMES1}' is expected."
 
-        xmlValidationService.validate(xml, ArrivalNotificationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+        xmlValidationService.validate(XML.loadString(xml), ArrivalNotificationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
       }
 
       "with invalid fields" in {
@@ -241,7 +246,25 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
         val expectedMessage =
           "The request has failed schema validation. Please review the required message structure as specified by the XSD file 'cc007a.xsd'. Detailed error below:\ncvc-pattern-valid: Value '11111111111111' is not facet-valid with respect to pattern '[a-zA-Z]{4}' for type 'Alpha_4'."
 
+        xmlValidationService.validate(XML.loadString(xml), ArrivalNotificationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+      }
+
+      "with an empty body" in {
+
+        val expectedMessage = "The request cannot be processed as it does not contain a request body."
+
+        xmlValidationService.validate(NodeSeq.Empty, ArrivalNotificationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+      }
+
+      "with an unexpected namespace" in {
+
+        val xml = XML.loadString(buildIE007Xml(with2001Namespace = true))
+
+        val expectedMessage =
+          "The request cannot be processed as it contains a namespace on the root node. Please remove any \"xmlns:\" attributes from all nodes."
+
         xmlValidationService.validate(xml, ArrivalNotificationXSD) mustBe Left(FailedToValidateXml(expectedMessage))
+
       }
     }
   }
@@ -252,7 +275,8 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
     withContainerTranshipment: Boolean = false,
     withVehicularTranshipment: Boolean = false,
     withSeals: Boolean = false,
-    withMessageType: String = "GB007A"
+    withMessageType: String = "GB007A",
+    with2001Namespace: Boolean = false
   ): String = {
 
     val enrouteEvent = {
@@ -261,8 +285,12 @@ class XmlValidationServiceSpec extends AnyFreeSpec with Matchers with ScalaCheck
       else ""
     }
 
+    val namespace =
+      if (with2001Namespace) "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\""
+      else ""
+
     s"""
-       |<CC007A>
+       |<CC007A $namespace>
        |    <SynIdeMES1>UNOC</SynIdeMES1>
        |    <SynVerNumMES2>3</SynVerNumMES2>
        |    <MesRecMES6>NCTS</MesRecMES6>

--- a/test/xml/CC007ASpec.scala
+++ b/test/xml/CC007ASpec.scala
@@ -30,15 +30,15 @@ class CC007ASpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks
   "validate" - {
 
     "must be successful when validating a valid CC007A xml" in {
-      xmlValidationService.validate(CC007A.toString(), ArrivalNotificationXSD) mustBe a[Right[_, _]]
+      xmlValidationService.validate(CC007A, ArrivalNotificationXSD) mustBe a[Right[_, _]]
     }
 
     "must fail when validating an invalid CC007A xml" in {
-      xmlValidationService.validate(InvalidCC007A.toString(), ArrivalNotificationXSD) mustBe a[Left[_, _]]
+      xmlValidationService.validate(InvalidCC007A, ArrivalNotificationXSD) mustBe a[Left[_, _]]
     }
 
     "must reject a CC007A containing MesSenMES3" in {
-      xmlValidationService.validate(CC007AwithMesSenMES3.toString(), ArrivalNotificationXSD) mustBe a[Left[_, _]]
+      xmlValidationService.validate(CC007AwithMesSenMES3, ArrivalNotificationXSD) mustBe a[Left[_, _]]
     }
   }
 }

--- a/test/xml/CC007ASpec.scala
+++ b/test/xml/CC007ASpec.scala
@@ -16,16 +16,21 @@
 
 package xml
 
+import config.AppConfig
 import data.TestXml
 import models.request.ArrivalNotificationXSD
+import org.mockito.Mockito.when
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import services.XmlValidationService
 
-class CC007ASpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks with TestXml {
+class CC007ASpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks with TestXml with MockitoSugar {
 
-  private val xmlValidationService = new XmlValidationService
+  private val mockAppConfig        = mock[AppConfig]
+  private val xmlValidationService = new XmlValidationService(mockAppConfig)
+  when(mockAppConfig.blockUnknownNamespaces).thenReturn(true)
 
   "validate" - {
 

--- a/test/xml/CC014ASpec.scala
+++ b/test/xml/CC014ASpec.scala
@@ -30,15 +30,15 @@ class CC014ASpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks
   "validate" - {
 
     "must be successful when validating a valid CC014A xml" in {
-      xmlValidationService.validate(CC014A.toString(), DeclarationCancellationRequestXSD) mustBe a[Right[_, _]]
+      xmlValidationService.validate(CC014A, DeclarationCancellationRequestXSD) mustBe a[Right[_, _]]
     }
 
     "must fail when validating an invalid CC014A xml" in {
-      xmlValidationService.validate(InvalidCC014A.toString(), DeclarationCancellationRequestXSD) mustBe a[Left[_, _]]
+      xmlValidationService.validate(InvalidCC014A, DeclarationCancellationRequestXSD) mustBe a[Left[_, _]]
     }
 
     "must reject a CC014A containing MesSenMES3" in {
-      xmlValidationService.validate(CC014AwithMesSenMES3.toString(), DeclarationCancellationRequestXSD) mustBe a[Left[_, _]]
+      xmlValidationService.validate(CC014AwithMesSenMES3, DeclarationCancellationRequestXSD) mustBe a[Left[_, _]]
     }
   }
 }

--- a/test/xml/CC014ASpec.scala
+++ b/test/xml/CC014ASpec.scala
@@ -16,16 +16,21 @@
 
 package xml
 
+import config.AppConfig
 import data.TestXml
 import models.request.DeclarationCancellationRequestXSD
+import org.mockito.Mockito.when
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import services.XmlValidationService
 
-class CC014ASpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks with TestXml {
+class CC014ASpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks with TestXml with MockitoSugar {
 
-  private val xmlValidationService = new XmlValidationService
+  private val mockAppConfig        = mock[AppConfig]
+  private val xmlValidationService = new XmlValidationService(mockAppConfig)
+  when(mockAppConfig.blockUnknownNamespaces).thenReturn(true)
 
   "validate" - {
 

--- a/test/xml/CC015BSpec.scala
+++ b/test/xml/CC015BSpec.scala
@@ -16,16 +16,21 @@
 
 package xml
 
+import config.AppConfig
 import data.TestXml
 import models.request.DepartureDeclarationXSD
+import org.mockito.Mockito.when
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import services.XmlValidationService
 
-class CC015BSpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks with TestXml {
+class CC015BSpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks with TestXml with MockitoSugar {
 
-  private val xmlValidationService = new XmlValidationService
+  private val mockAppConfig        = mock[AppConfig]
+  private val xmlValidationService = new XmlValidationService(mockAppConfig)
+  when(mockAppConfig.blockUnknownNamespaces).thenReturn(true)
 
   "validate" - {
 

--- a/test/xml/CC015BSpec.scala
+++ b/test/xml/CC015BSpec.scala
@@ -30,15 +30,15 @@ class CC015BSpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks
   "validate" - {
 
     "must be successful when validating a valid CC015B xml" in {
-      xmlValidationService.validate(CC015B.toString(), DepartureDeclarationXSD) mustBe a[Right[_, _]]
+      xmlValidationService.validate(CC015B, DepartureDeclarationXSD) mustBe a[Right[_, _]]
     }
 
     "must fail when validating an invalid CC015B xml" in {
-      xmlValidationService.validate(InvalidCC015B.toString(), DepartureDeclarationXSD) mustBe a[Left[_, _]]
+      xmlValidationService.validate(InvalidCC015B, DepartureDeclarationXSD) mustBe a[Left[_, _]]
     }
 
     "must reject a CC015B containing MesSenMES3" in {
-      xmlValidationService.validate(CC015BwithMesSenMES3.toString(), DepartureDeclarationXSD) mustBe a[Left[_, _]]
+      xmlValidationService.validate(CC015BwithMesSenMES3, DepartureDeclarationXSD) mustBe a[Left[_, _]]
     }
   }
 }

--- a/test/xml/CC044ASpec.scala
+++ b/test/xml/CC044ASpec.scala
@@ -16,16 +16,21 @@
 
 package xml
 
+import config.AppConfig
 import data.TestXml
 import models.request.UnloadingRemarksXSD
+import org.mockito.Mockito.when
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import services.XmlValidationService
 
-class CC044ASpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks with TestXml {
+class CC044ASpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks with TestXml with MockitoSugar {
 
-  private val xmlValidationService = new XmlValidationService
+  private val mockAppConfig        = mock[AppConfig]
+  private val xmlValidationService = new XmlValidationService(mockAppConfig)
+  when(mockAppConfig.blockUnknownNamespaces).thenReturn(true)
 
   "validate" - {
 

--- a/test/xml/CC044ASpec.scala
+++ b/test/xml/CC044ASpec.scala
@@ -30,15 +30,15 @@ class CC044ASpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks
   "validate" - {
 
     "must be successful when validating a valid CC044A xml" in {
-      xmlValidationService.validate(CC044A.toString(), UnloadingRemarksXSD) mustBe a[Right[_, _]]
+      xmlValidationService.validate(CC044A, UnloadingRemarksXSD) mustBe a[Right[_, _]]
     }
 
     "must fail when validating an invalid CC044A xml" in {
-      xmlValidationService.validate(InvalidCC044A.toString(), UnloadingRemarksXSD) mustBe a[Left[_, _]]
+      xmlValidationService.validate(InvalidCC044A, UnloadingRemarksXSD) mustBe a[Left[_, _]]
     }
 
     "must reject a CC044A containing MesSenMES3" in {
-      xmlValidationService.validate(CC044AwithMesSenMES3.toString(), UnloadingRemarksXSD) mustBe a[Left[_, _]]
+      xmlValidationService.validate(CC044AwithMesSenMES3, UnloadingRemarksXSD) mustBe a[Left[_, _]]
     }
   }
 }


### PR DESCRIPTION
This reverts commit 9155c4702b998bcbda26ba3a945ea96529ed7899, but allowing explicitly null/empty namespaces.

This is the original commit for CTDA-1861 plus an additional allowance for the `xmlns=""` namespace (see the second commit).

Also added a config option `xml-validation.block-unknown-namespaces` that we can use to control this without otherwise touching the code.