### PR TITLE
CTCP-266: PoC on how we could wrap XML in JSON

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,10 +6,11 @@ object AppDependencies {
   private val catsVersion = "2.6.1"
 
   val compile = Seq(
-    "uk.gov.hmrc"   %% "bootstrap-backend-play-28" % "5.16.0",
-    "org.typelevel" %% "cats-core"                 % catsVersion,
-    "org.json"       % "json"                      % "20210307",
-    "io.lemonlabs"  %% "scala-uri"                 % "3.6.0"
+    "uk.gov.hmrc"        %% "bootstrap-backend-play-28" % "5.16.0",
+    "org.typelevel"      %% "cats-core"                 % catsVersion,
+    "org.json"            % "json"                      % "20210307",
+    "io.lemonlabs"       %% "scala-uri"                 % "3.6.0",
+    "com.lightbend.akka" %% "akka-stream-alpakka-xml"   % "3.0.4"
   )
 
   val test = Seq(


### PR DESCRIPTION
**Don't merge this** - this is strictly a PoC to show creating JSON without having to load an entire stream into memory, and it isn't that pretty!

I was having a look at seeing if we can generate JSON with the streaming parser - and the answer was yes. However, because of the fact we have potentially got a lot of XML coming in, doing it in a "traditional" manner would end up loading the entire XML string in memory, which we might not want to happen. Thus, I looked to see if we could piecemeal JSON using graphs and bytestring concatenation - which we could do like this.

However, this does reduce the performance - in memory, we've gone from 15ms to 90ms+. Not _terrible_, but we are basically manipulating the stream. We also have the problem of parsing the JSON blob on the other end, looking into this we might find that parsing it out might be memory intensive due to the way Alpakka parses this.

We need to have a think about what we're going to want to get out of the XML and where. While I was in favour of JSON wrapped XML previously, having done this work and investigating Alpakka, I think from a performance point of view, we may be better served looking at another option for inter-µservice, such as URL or headers, as most services will just want the XML unscathed (such as the validation service) and will only want one or two other pieces of information.