### PR TITLE
CTCP-266: Move v2 code into v2 package and add departures router to separate routing from the v1 code

### DIFF
--- a/app/routing/DeparturesRouter.scala
+++ b/app/routing/DeparturesRouter.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package routing
+
+import akka.stream.Materializer
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import com.google.inject.Inject
+import controllers.V1DeparturesController
+import play.api.mvc.Action
+import play.api.mvc.BaseController
+import play.api.mvc.ControllerComponents
+import v2.controllers.V2DeparturesController
+import v2.controllers.stream.StreamingParsers
+
+class DeparturesRouter @Inject()(val controllerComponents: ControllerComponents,
+                                 v1Departures: V1DeparturesController,
+                                 v2Departures: V2DeparturesController
+                                 )(implicit val materializer: Materializer)
+  extends BaseController
+    with StreamingParsers
+    with VersionedRouting {
+
+  def submitDeclaration(): Action[Source[ByteString, _]] = route {
+    case Some("application/vnd.hmrc.2.0+json") => v2Departures.submitDeclaration()
+    case _                                     => v1Departures.submitDeclaration()
+  }
+
+}

--- a/app/routing/VersionedRouting.scala
+++ b/app/routing/VersionedRouting.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers.stream
+package routing
 
 import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
@@ -24,6 +24,7 @@ import play.api.libs.json.Json
 import play.api.mvc.Action
 import play.api.mvc.BaseController
 import play.api.mvc.Request
+import v2.controllers.stream.StreamingParsers
 import v2.models.errors.BaseError
 
 import scala.concurrent.Future

--- a/app/v2/controllers/V2DeparturesController.scala
+++ b/app/v2/controllers/V2DeparturesController.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.controllers
+
+import akka.stream.Materializer
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import com.google.inject.ImplementedBy
+import com.google.inject.Inject
+import com.google.inject.Singleton
+import play.api.Logging
+import play.api.mvc.Action
+import play.api.mvc.BaseController
+import play.api.mvc.ControllerComponents
+import routing.VersionedRouting
+import v2.controllers.actions.AuthNewEnrolmentOnlyAction
+import v2.controllers.actions.MessageSizeAction
+import v2.controllers.stream.StreamingParsers
+
+import scala.concurrent.Future
+
+@ImplementedBy(classOf[V2DeparturesControllerImpl])
+trait V2DeparturesController {
+
+  def submitDeclaration(): Action[Source[ByteString, _]]
+
+}
+
+@Singleton
+class V2DeparturesControllerImpl @Inject() (
+    val controllerComponents: ControllerComponents,
+    authActionNewEnrolmentOnly: AuthNewEnrolmentOnlyAction,
+    messageSizeAction: MessageSizeAction)(implicit val materializer: Materializer) extends BaseController
+  with V2DeparturesController
+  with Logging
+  with StreamingParsers
+  with VersionedRouting {
+
+  def submitDeclaration(): Action[Source[ByteString, _]] =
+    (authActionNewEnrolmentOnly andThen messageSizeAction).async(streamFromMemory) {
+      request =>
+        // TODO: When streaming to the validation service, we will want to keep a copy of the
+        //  stream so we can replay it. We will need to do one of two things:
+        //  * Stream to a temporary file, then stream off it twice
+        //  * Stream from memory to the validation service AND a file, then stream FROM the file if we get the OK
+        //  The first option will likely be more stable but slower than the second option.
+
+        // Because we have an open stream, we **must** do something with it. For now, we send it to the ignore sink.
+        request.body.to(Sink.ignore).run()
+        logger.info("Version 2 of endpoint has been called")
+        Future.successful(Accepted)
+    }
+
+}

--- a/app/v2/controllers/actions/AuthNewEnrolmentOnlyAction.scala
+++ b/app/v2/controllers/actions/AuthNewEnrolmentOnlyAction.scala
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-package controllers.actions
+package v2.controllers.actions
 
 import com.google.inject.Inject
 import config.Constants._
+import controllers.actions.AuthRequest
 import play.api.Logging
+import play.api.libs.json.Json
 import play.api.mvc.Results._
 import play.api.mvc._
-import play.api.libs.json.Json
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
 import uk.gov.hmrc.http.HeaderCarrier

--- a/app/v2/controllers/actions/MessageSizeAction.scala
+++ b/app/v2/controllers/actions/MessageSizeAction.scala
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-package controllers.actions
+package v2.controllers.actions
 
 import com.google.inject.Inject
 import config.AppConfig
 import play.api.http.HeaderNames
 import play.api.libs.json.Json
-import play.api.mvc.Results.BadRequest
-import play.api.mvc.Results.EntityTooLarge
 import play.api.mvc.ActionRefiner
 import play.api.mvc.Request
 import play.api.mvc.Result
+import play.api.mvc.Results.BadRequest
+import play.api.mvc.Results.EntityTooLarge
 import v2.models.errors.BaseError
 
 import scala.concurrent.ExecutionContext

--- a/app/v2/controllers/stream/StreamingParsers.scala
+++ b/app/v2/controllers/stream/StreamingParsers.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers.stream
+package v2.controllers.stream
 
 import akka.stream.IOResult
 import akka.stream.Materializer

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -12,7 +12,7 @@ GET        /movements/arrivals/:arrivalId/messages/:messageId       controllers.
 
 
 GET        /movements/departures                                    controllers.DeparturesController.getDeparturesForEori(updatedSince: Option[OffsetDateTime] ?= None)
-POST       /movements/departures                                    controllers.DeparturesController.submitDeclaration()
+POST       /movements/departures                                    routing.DeparturesRouter.submitDeclaration()
 
 GET        /movements/departures/:departureId                       controllers.DeparturesController.getDeparture(departureId: DepartureId)
 

--- a/test/routing/DeparturesRouterSpec.scala
+++ b/test/routing/DeparturesRouterSpec.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package routing
+
+import akka.util.Timeout
+import controllers.V1DeparturesController
+import org.scalatest.OptionValues
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.http.HeaderNames
+import play.api.http.Status.ACCEPTED
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.Json
+import play.api.test.FakeHeaders
+import play.api.test.FakeRequest
+import play.api.test.Helpers.contentAsJson
+import play.api.test.Helpers.route
+import play.api.test.Helpers.status
+import v2.controllers.V2DeparturesController
+import v2.fakes.controllers.FakeV1DeparturesController
+import v2.fakes.controllers.FakeV2DeparturesController
+
+import scala.concurrent.duration.DurationInt
+
+class DeparturesRouterSpec extends AnyFreeSpec with Matchers
+  with OptionValues
+  with ScalaFutures
+  with MockitoSugar
+  with GuiceOneAppPerSuite {
+
+  private implicit val timeout: Timeout = 5.seconds
+
+  override lazy val app = GuiceApplicationBuilder()
+    .overrides(
+      bind[V1DeparturesController].to[FakeV1DeparturesController],
+      bind[V2DeparturesController].to[FakeV2DeparturesController]
+    )
+    .build()
+
+  // Version 2
+  "with accept header set to application/vnd.hmrc.2.0+json (version two)" - {
+
+    val departureHeaders = FakeHeaders(Seq(HeaderNames.ACCEPT -> "application/vnd.hmrc.2.0+json", HeaderNames.CONTENT_TYPE -> "application/xml"))
+
+    "must route to the v2 controller and return Accepted when successful" in {
+
+      val request = FakeRequest(method = "POST", uri = routes.DeparturesRouter.submitDeclaration().url, body = <test></test>, headers = departureHeaders)
+      val result  = route(app, request).value
+
+      status(result) mustBe ACCEPTED
+      contentAsJson(result) mustBe Json.obj("version" -> 2) // ensure we get the unique value to verify we called the fake action
+    }
+
+  }
+
+  Seq(None, Some("application/vnd.hmrc.1.0+json"), Some("text/html"), Some("application/vnd.hmrc.1.0+xml"), Some("text/javascript")).foreach {
+    acceptHeaderValue =>
+      val acceptHeader = acceptHeaderValue
+        .map(
+          header => Seq(HeaderNames.ACCEPT -> header)
+        )
+        .getOrElse(Seq.empty)
+      val departureHeaders = FakeHeaders(acceptHeader ++ Seq(HeaderNames.CONTENT_TYPE -> "application/xml"))
+      val withString = acceptHeaderValue
+        .getOrElse("nothing")
+      s"with accept header set to $withString" - {
+
+        "must route to the v1 controller and return Accepted when successful" in {
+
+          val request = FakeRequest(method = "POST", uri = routes.DeparturesRouter.submitDeclaration().url, body = <test></test>, headers = departureHeaders)
+          val result = route(app, request).value
+
+          status(result) mustBe ACCEPTED
+          contentAsJson(result) mustBe Json.obj("version" -> 1) // ensure we get the unique value to verify we called the fake action
+        }
+      }
+
+  }
+}

--- a/test/routing/VersionedRoutingSpec.scala
+++ b/test/routing/VersionedRoutingSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers.stream
+package routing
 
 import akka.NotUsed
 import akka.stream.Materializer
@@ -38,6 +38,7 @@ import play.api.test.Helpers.contentAsString
 import play.api.test.Helpers.defaultAwaitTimeout
 import play.api.test.Helpers.status
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+import v2.controllers.stream.StreamingParsers
 
 import java.nio.charset.StandardCharsets
 import scala.collection.immutable

--- a/test/v2/controllers/V2DeparturesControllerSpec.scala
+++ b/test/v2/controllers/V2DeparturesControllerSpec.scala
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.controllers
+
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import akka.util.Timeout
+import org.scalatest.OptionValues
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.http.HeaderNames
+import play.api.http.Status.ACCEPTED
+import play.api.http.Status.BAD_REQUEST
+import play.api.http.Status.REQUEST_ENTITY_TOO_LARGE
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.mvc.Request
+import play.api.test.FakeHeaders
+import play.api.test.FakeRequest
+import play.api.test.Helpers.route
+import play.api.test.Helpers.status
+import v2.controllers.actions.AuthNewEnrolmentOnlyAction
+import v2.fakes.controllers.actions.FakeAuthNewEnrolmentOnlyAction
+
+import java.nio.charset.StandardCharsets
+import scala.concurrent.duration.DurationInt
+import scala.xml.NodeSeq
+
+class V2DeparturesControllerSpec extends AnyFreeSpec
+  with Matchers
+  with GuiceOneAppPerSuite
+  with OptionValues
+  with ScalaFutures
+  with MockitoSugar {
+
+  // TODO: Make this a cc015c
+  def CC015C: NodeSeq =
+      <CC015B>
+        <SynIdeMES1>UNOC</SynIdeMES1>
+        <SynVerNumMES2>3</SynVerNumMES2>
+        <MesRecMES6>NCTS</MesRecMES6>
+        <DatOfPreMES9>20201217</DatOfPreMES9>
+        <TimOfPreMES10>1340</TimOfPreMES10>
+        <IntConRefMES11>17712576475433</IntConRefMES11>
+        <AppRefMES14>NCTS</AppRefMES14>
+        <MesIdeMES19>1</MesIdeMES19>
+        <MesTypMES20>GB015B</MesTypMES20>
+        <HEAHEA>
+          <RefNumHEA4>GUATEST1201217134032</RefNumHEA4>
+          <TypOfDecHEA24>T1</TypOfDecHEA24>
+          <CouOfDesCodHEA30>IT</CouOfDesCodHEA30>
+          <AutLocOfGooCodHEA41>954131533-GB60DEP</AutLocOfGooCodHEA41>
+          <CouOfDisCodHEA55>GB</CouOfDisCodHEA55>
+          <IdeOfMeaOfTraAtDHEA78>NC15 REG</IdeOfMeaOfTraAtDHEA78>
+          <NatOfMeaOfTraAtDHEA80>GB</NatOfMeaOfTraAtDHEA80>
+          <ConIndHEA96>0</ConIndHEA96>
+          <NCTSAccDocHEA601LNG>EN</NCTSAccDocHEA601LNG>
+          <TotNumOfIteHEA305>1</TotNumOfIteHEA305>
+          <TotNumOfPacHEA306>10</TotNumOfPacHEA306>
+          <TotGroMasHEA307>1000</TotGroMasHEA307>
+          <DecDatHEA383>20201217</DecDatHEA383>
+          <DecPlaHEA394>Dover</DecPlaHEA394>
+        </HEAHEA>
+        <TRAPRIPC1>
+          <NamPC17>NCTS UK TEST LAB HMCE</NamPC17>
+          <StrAndNumPC122>11TH FLOOR, ALEX HOUSE, VICTORIA AV</StrAndNumPC122>
+          <PosCodPC123>SS99 1AA</PosCodPC123>
+          <CitPC124>SOUTHEND-ON-SEA, ESSEX</CitPC124>
+          <CouPC125>GB</CouPC125>
+          <TINPC159>GB954131533000</TINPC159>
+        </TRAPRIPC1>
+        <TRACONCO1>
+          <NamCO17>NCTS UK TEST LAB HMCE</NamCO17>
+          <StrAndNumCO122>11TH FLOOR, ALEX HOUSE, VICTORIA AV</StrAndNumCO122>
+          <PosCodCO123>SS99 1AA</PosCodCO123>
+          <CitCO124>SOUTHEND-ON-SEA, ESSEX</CitCO124>
+          <CouCO125>GB</CouCO125>
+          <TINCO159>GB954131533000</TINCO159>
+        </TRACONCO1>
+        <TRACONCE1>
+          <NamCE17>NCTS UK TEST LAB HMCE</NamCE17>
+          <StrAndNumCE122>ITALIAN OFFICE</StrAndNumCE122>
+          <PosCodCE123>IT99 1IT</PosCodCE123>
+          <CitCE124>MILAN</CitCE124>
+          <CouCE125>IT</CouCE125>
+          <TINCE159>IT11ITALIANC11</TINCE159>
+        </TRACONCE1>
+        <CUSOFFDEPEPT>
+          <RefNumEPT1>GB000060</RefNumEPT1>
+        </CUSOFFDEPEPT>
+        <CUSOFFTRARNS>
+          <RefNumRNS1>FR001260</RefNumRNS1>
+          <ArrTimTRACUS085>202012191340</ArrTimTRACUS085>
+        </CUSOFFTRARNS>
+        <CUSOFFDESEST>
+          <RefNumEST1>IT018100</RefNumEST1>
+        </CUSOFFDESEST>
+        <CONRESERS>
+          <ConResCodERS16>A3</ConResCodERS16>
+          <DatLimERS69>20201225</DatLimERS69>
+        </CONRESERS>
+        <SEAINFSLI>
+          <SeaNumSLI2>1</SeaNumSLI2>
+          <SEAIDSID>
+            <SeaIdeSID1>NCTS001</SeaIdeSID1>
+          </SEAIDSID>
+        </SEAINFSLI>
+        <GUAGUA>
+          <GuaTypGUA1>0</GuaTypGUA1>
+          <GUAREFREF>
+            <GuaRefNumGRNREF1>20GB0000010000H72</GuaRefNumGRNREF1>
+            <AccCodREF6>AC01</AccCodREF6>
+          </GUAREFREF>
+        </GUAGUA>
+        <GOOITEGDS>
+          <IteNumGDS7>1</IteNumGDS7>
+          <GooDesGDS23>Wheat</GooDesGDS23>
+          <GooDesGDS23LNG>EN</GooDesGDS23LNG>
+          <GroMasGDS46>1000</GroMasGDS46>
+          <NetMasGDS48>950</NetMasGDS48>
+          <SPEMENMT2>
+            <AddInfMT21>20GB0000010000H72</AddInfMT21>
+            <AddInfCodMT23>CAL</AddInfCodMT23>
+          </SPEMENMT2>
+          <PACGS2>
+            <MarNumOfPacGS21>AB234</MarNumOfPacGS21>
+            <KinOfPacGS23>BX</KinOfPacGS23>
+            <NumOfPacGS24>10</NumOfPacGS24>
+          </PACGS2>
+        </GOOITEGDS>
+      </CC015B>
+
+  override lazy val app = GuiceApplicationBuilder()
+    .overrides(
+      bind[AuthNewEnrolmentOnlyAction].to[FakeAuthNewEnrolmentOnlyAction]
+    )
+    .build()
+  lazy val sut: V2DeparturesController = app.injector.instanceOf[V2DeparturesController]
+
+  implicit val timeout: Timeout = 5.seconds
+
+  def fakeRequestDepartures[A](
+    method: String,
+    headers: FakeHeaders = FakeHeaders(Seq(HeaderNames.CONTENT_TYPE -> "application/xml")),
+    uri: String = routing.routes.DeparturesRouter.submitDeclaration().url,
+    body: A
+  ): Request[A] =
+    FakeRequest(method = method, uri = uri, headers = headers, body = body)
+
+  // Version 2
+  "with accept header set to application/vnd.hmrc.2.0+json (version two)" - {
+
+    // For the content length headers, we have to ensure that we send something
+    val standardHeaders = FakeHeaders(Seq(HeaderNames.ACCEPT -> "application/vnd.hmrc.2.0+json", HeaderNames.CONTENT_TYPE -> "application/xml", HeaderNames.CONTENT_LENGTH -> "1000"))
+
+    "must return BadRequest when content length is not sent" in {
+      val departureHeaders = FakeHeaders(
+        Seq(HeaderNames.ACCEPT -> "application/vnd.hmrc.2.0+json", HeaderNames.CONTENT_TYPE -> "application/xml")
+      )
+      // We emulate no ContentType by sending in a stream directly, without going through Play's request builder
+      val request = fakeRequestDepartures(method = "POST", body = Source.single(ByteString(CC015C.mkString, StandardCharsets.UTF_8)), headers = departureHeaders)
+      val result  = app.injector.instanceOf[V2DeparturesController].submitDeclaration()(request)
+      status(result) mustBe BAD_REQUEST
+    }
+
+    "must return RequestEntityTooLarge when body size exceeds limit" in {
+      val departureHeaders = FakeHeaders(
+        Seq(HeaderNames.ACCEPT -> "application/vnd.hmrc.2.0+json", HeaderNames.CONTENT_TYPE -> "application/xml", HeaderNames.CONTENT_LENGTH -> "500001")
+      )
+      val request = fakeRequestDepartures(method = "POST", body = CC015C, headers = departureHeaders)
+      val result  = route(app, request).value
+      status(result) mustBe REQUEST_ENTITY_TOO_LARGE
+    }
+
+    "must return Accepted when body length is within limits" in {
+      val request = fakeRequestDepartures(method = "POST", body = CC015C, headers = standardHeaders)
+      val result  = route(app, request).value
+      status(result) mustBe ACCEPTED
+    }
+  }
+
+}

--- a/test/v2/controllers/actions/AuthNewEnrolmentOnlyActionSpec.scala
+++ b/test/v2/controllers/actions/AuthNewEnrolmentOnlyActionSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers.actions
+package v2.controllers.actions
 
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._

--- a/test/v2/controllers/actions/MessageSizeActionSpec.scala
+++ b/test/v2/controllers/actions/MessageSizeActionSpec.scala
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-package controllers.actions
+package v2.controllers.actions
 
+import controllers.actions.AuthAction
+import controllers.actions.FakeAuthAction
 import data.TestXml
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
@@ -27,10 +29,10 @@ import play.api.http.HeaderNames
 import play.api.http.HttpVerbs
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.test.Helpers._
 import play.api.mvc._
 import play.api.test.FakeHeaders
 import play.api.test.FakeRequest
+import play.api.test.Helpers._
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/test/v2/controllers/stream/StreamingParsersSpec.scala
+++ b/test/v2/controllers/stream/StreamingParsersSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers.stream
+package v2.controllers.stream
 
 import akka.NotUsed
 import akka.stream.Materializer

--- a/test/v2/fakes/controllers/FakeV1DeparturesController.scala
+++ b/test/v2/fakes/controllers/FakeV1DeparturesController.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.fakes.controllers
+
+import controllers.V1DeparturesController
+import play.api.libs.json.Json
+import play.api.mvc.Action
+import play.api.mvc.BaseController
+import play.api.mvc.Request
+import play.api.test.Helpers.stubControllerComponents
+
+import scala.xml.NodeSeq
+
+class FakeV1DeparturesController extends BaseController with V1DeparturesController {
+
+  override val controllerComponents = stubControllerComponents()
+
+  override def submitDeclaration(): Action[NodeSeq] = Action(parse.xml) {
+    _: Request[NodeSeq] =>
+      Accepted(Json.obj("version" -> 1))
+  }
+
+}

--- a/test/v2/fakes/controllers/FakeV2DeparturesController.scala
+++ b/test/v2/fakes/controllers/FakeV2DeparturesController.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.fakes.controllers
+
+import akka.stream.Materializer
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import com.google.inject.Inject
+import play.api.libs.json.Json
+import play.api.mvc.Action
+import play.api.mvc.BaseController
+import play.api.test.Helpers.stubControllerComponents
+import v2.controllers.V2DeparturesController
+import v2.controllers.stream.StreamingParsers
+
+class FakeV2DeparturesController @Inject() ()(implicit val materializer: Materializer)
+  extends BaseController with V2DeparturesController with StreamingParsers {
+
+  override val controllerComponents = stubControllerComponents()
+
+  override def submitDeclaration(): Action[Source[ByteString, _]] = Action(streamFromMemory) {
+    request =>
+      request.body.runWith(Sink.ignore)
+      Accepted(Json.obj("version" -> 2))
+  }
+
+}

--- a/test/v2/fakes/controllers/actions/FakeAuthNewEnrolmentOnlyAction.scala
+++ b/test/v2/fakes/controllers/actions/FakeAuthNewEnrolmentOnlyAction.scala
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-package controllers.actions
+package v2.fakes.controllers.actions
 
 import com.google.inject.Inject
 import config.AppConfig
-import play.api.mvc._
-import uk.gov.hmrc.auth.core._
+import controllers.actions.AuthRequest
+import play.api.mvc.BodyParsers
+import play.api.mvc.Request
+import play.api.mvc.Result
+import uk.gov.hmrc.auth.core.AuthConnector
+import v2.controllers.actions.AuthNewEnrolmentOnlyAction
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future


### PR DESCRIPTION
**Depends on #251 and #256**

Once the above two PRs are merged, only the last commit will be relavant for this PR. This moves all v2 code into its own package and separates out the routing code into its own controller (`DepraturesRouter`).

This will enable writing the Validation connector in the correct place.

Will rebase once the two PRs above are merged (or fates otherwise decided)