### PR TITLE
CTCP-271: Update API Definition

### DIFF
--- a/resources/public/api/conf/2.0/application.raml
+++ b/resources/public/api/conf/2.0/application.raml
@@ -62,6 +62,17 @@ traits:
                 description: The request body is too large
                 value:
                   code: REQUEST_ENTITY_TOO_LARGE
+  schemaValidation:
+    responses:
+      400:
+        body:
+          application/json:
+            type: types.errorResponse
+            examples:
+              schemaValidation:
+                description: The request body failed schema validation
+                value:
+                  code: SCHEMA_VALIDATION
 
 /customs/transits/movements:
   /departures:
@@ -78,6 +89,7 @@ traits:
         - contentXmlHeader
         - acceptJsonHeader
         - requestTooLarge
+        - schemaValidation
       (annotations.scope): "common-transit-convention-traders"
       securedBy: [ sec.oauth_2_0: { scopes: [ "common-transit-convention-traders" ] } ]
       responses:

--- a/resources/public/api/conf/2.0/docs/errors.md
+++ b/resources/public/api/conf/2.0/docs/errors.md
@@ -3,7 +3,9 @@ We use standard HTTP status codes to show whether an API request has succeeded o
 
 **POST**
 
-400 BadRequest: XML has failed validation - see response body for details
+400 BadRequest: The "code" field in the Json body provides the exact cause:
+
+* `SCHEMA_VALIDATION`: The request body failed to validate against the appropriate schema, check the `validationErrors` field for more details
 
 401 Unauthorized: If client passes invalid auth credentials
 
@@ -21,7 +23,9 @@ We use standard HTTP status codes to show whether an API request has succeeded o
 
 **PUT**
 
-400 BadRequest: If XML message is invalid
+400 BadRequest: The "code" field in the Json body provides the exact cause:
+
+* `SCHEMA_VALIDATION`: The request body failed to validate against the appropriate schema, check the `validationErrors` field for more details
 
 401 Unauthorized: If client passes invalid auth credentials
 
@@ -41,7 +45,7 @@ We use standard HTTP status codes to show whether an API request has succeeded o
 
 403 Forbidden: If supplied auth token doesn't contain valid enrolment
 
-404 Not Found: If no object with specified ID found in database. Or if client passes in an ``Accept`` header which contains the wrong API version number. We have only released version 1.0 of the API
+404 Not Found: If no object with specified ID found in database. Or if client passes in an ``Accept`` header which contains the wrong API version number.
 
 415 Unsupported Media Type: If ``Accept`` header contains invalid type
 
@@ -50,3 +54,28 @@ We use standard HTTP status codes to show whether an API request has succeeded o
 
 Errors specific to each API are shown in the Endpoints section, under Response.
 See our [reference guide](https://developer.service.hmrc.gov.uk/api-documentation/docs/reference-guide#errors) for more on errors.
+
+### Schema Validation Error Responses
+
+If a request fails to pass validation, the response body will contain a list of validation errors in the "validationErrors" field. Each error will contain the fields "lineNumber", "columnNumber" and "message". 
+
+An example response for a request that failed to validate can be found below:
+
+```json
+{
+  "message": "Request failed schema validation",
+  "code": "SCHEMA_VALIDATION",
+  "validationErrors": [
+    {
+      "lineNumber": 4,
+      "columnNumber": 60,
+      "message": "cvc-pattern-valid: Value 'notatime' is not facet-valid with respect to pattern '\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}' for type 'PreparationDateAndTimeContentType'."
+    },
+    {
+      "lineNumber": 4,
+      "columnNumber": 60,
+      "message": "cvc-type.3.1.3: The value 'notatime' of element 'preparationDateAndTime' is not valid."
+    }
+  ]
+}
+```

--- a/resources/public/api/conf/2.0/docs/errors.md
+++ b/resources/public/api/conf/2.0/docs/errors.md
@@ -5,7 +5,7 @@ We use standard HTTP status codes to show whether an API request has succeeded o
 
 400 BadRequest: The "code" field in the Json body provides the exact cause:
 
-* `SCHEMA_VALIDATION`: The request body failed to validate against the appropriate schema, check the `validationErrors` field for more details
+* `SCHEMA_VALIDATION`: The request body failed to validate against the appropriate schema. Check the `validationErrors` field for more details.
 
 401 Unauthorized: If client passes invalid auth credentials
 
@@ -25,7 +25,7 @@ We use standard HTTP status codes to show whether an API request has succeeded o
 
 400 BadRequest: The "code" field in the Json body provides the exact cause:
 
-* `SCHEMA_VALIDATION`: The request body failed to validate against the appropriate schema, check the `validationErrors` field for more details
+* `SCHEMA_VALIDATION`: The request body failed to validate against the appropriate schema. Check the `validationErrors` field for more details.
 
 401 Unauthorized: If client passes invalid auth credentials
 


### PR DESCRIPTION
_Note that this PR is a draft as it is awaiting merge of CTCP-266, #255._

Adds text to the API definition as follows:

* Clarifies that the code from any BadRequest error is important - though we only have `SCHEMA_VALIDATION` at the moment (could there be more?)
* Adds a section under Errors with the form of the error that is returned (do we want this here, or should this go elsewhere?)
* Adds a trait to the RAML to allow adding schema validation to other endpoints as they get written.