### PR TITLE
Return 500 in AuthAction when auth service returns an error response

### DIFF
--- a/app/controllers/actions/AuthAction.scala
+++ b/app/controllers/actions/AuthAction.scala
@@ -30,6 +30,7 @@ import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.util.control.NonFatal
 
 class AuthAction @Inject() (
   override val authConnector: AuthConnector,
@@ -88,5 +89,8 @@ class AuthAction @Inject() (
     case e: AuthorisationException =>
       logger.warn(s"Failed to authorise", e)
       Unauthorized
+    case NonFatal(thr) =>
+      logger.error(s"Error returned from auth service: ${thr.getMessage}", thr)
+      InternalServerError
   }
 }

--- a/app/controllers/actions/AuthAction.scala
+++ b/app/controllers/actions/AuthAction.scala
@@ -20,6 +20,7 @@ import com.google.inject.Inject
 import config.Constants
 import config.Constants._
 import play.api.Logging
+import play.api.libs.json.Json
 import play.api.mvc.Results._
 import play.api.mvc._
 import services.EnrolmentLoggingService
@@ -27,6 +28,7 @@ import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.http.HeaderCarrierConverter
+import v2.models.errors.PresentationError
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -88,9 +90,9 @@ class AuthAction @Inject() (
       Forbidden("Current user doesn't have a valid EORI enrolment.")
     case e: AuthorisationException =>
       logger.warn(s"Failed to authorise", e)
-      Unauthorized
+      Unauthorized(Json.toJson(PresentationError.unauthorized(s"Failed to authorise user: ${e.reason}")))
     case NonFatal(thr) =>
       logger.error(s"Error returned from auth service: ${thr.getMessage}", thr)
-      InternalServerError
+      InternalServerError(Json.toJson(PresentationError.internalServiceError(cause = Some(thr))))
   }
 }

--- a/app/v2/controllers/actions/AuthNewEnrolmentOnlyAction.scala
+++ b/app/v2/controllers/actions/AuthNewEnrolmentOnlyAction.scala
@@ -77,9 +77,9 @@ class AuthNewEnrolmentOnlyActionImpl @Inject() (override val authConnector: Auth
       Forbidden(Json.toJson(PresentationError.forbiddenError("Current user doesn't have a valid EORI enrolment.")))
     case e: AuthorisationException =>
       logger.warn(s"Failed to authorise", e)
-      Unauthorized
+      Unauthorized(Json.toJson(PresentationError.unauthorized(s"Failed to authorise user: ${e.reason}")))
     case NonFatal(thr) =>
       logger.error(s"Error returned from auth service: ${thr.getMessage}", thr)
-      InternalServerError
+      InternalServerError(Json.toJson(PresentationError.internalServiceError(cause = Some(thr))))
   }
 }

--- a/app/v2/controllers/actions/AuthNewEnrolmentOnlyAction.scala
+++ b/app/v2/controllers/actions/AuthNewEnrolmentOnlyAction.scala
@@ -33,6 +33,7 @@ import v2.models.errors.PresentationError
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.util.control.NonFatal
 
 @ImplementedBy(classOf[AuthNewEnrolmentOnlyActionImpl])
 trait AuthNewEnrolmentOnlyAction extends ActionBuilder[AuthenticatedRequest, AnyContent] with ActionFunction[Request, AuthenticatedRequest]
@@ -77,5 +78,8 @@ class AuthNewEnrolmentOnlyActionImpl @Inject() (override val authConnector: Auth
     case e: AuthorisationException =>
       logger.warn(s"Failed to authorise", e)
       Unauthorized
+    case NonFatal(thr) =>
+      logger.error(s"Error returned from auth service: ${thr.getMessage}", thr)
+      InternalServerError
   }
 }

--- a/app/v2/models/errors/ErrorCode.scala
+++ b/app/v2/models/errors/ErrorCode.scala
@@ -34,6 +34,7 @@ object ErrorCode {
   case object SchemaValidation     extends ErrorCode("SCHEMA_VALIDATION", BAD_REQUEST)
   case object EntityTooLarge       extends ErrorCode("REQUEST_ENTITY_TOO_LARGE", REQUEST_ENTITY_TOO_LARGE)
   case object UnsupportedMediaType extends ErrorCode("UNSUPPORTED_MEDIA_TYPE", UNSUPPORTED_MEDIA_TYPE)
+  case object Unauthorized         extends ErrorCode("UNAUTHORIZED", UNAUTHORIZED)
 
   lazy val errorCodes: Seq[ErrorCode] = Seq(
     BadRequest,
@@ -43,7 +44,8 @@ object ErrorCode {
     GatewayTimeout,
     SchemaValidation,
     EntityTooLarge,
-    UnsupportedMediaType
+    UnsupportedMediaType,
+    Unauthorized
   )
 
   implicit val errorCodeWrites: Writes[ErrorCode] = Writes {

--- a/app/v2/models/errors/PresentationError.scala
+++ b/app/v2/models/errors/PresentationError.scala
@@ -46,6 +46,9 @@ object PresentationError extends CommonFormats {
   def notFoundError(message: String): PresentationError =
     StandardError(message, ErrorCode.NotFound)
 
+  def unauthorized(message: String): PresentationError =
+    StandardError(message, ErrorCode.Unauthorized)
+
   def schemaValidationError(message: String = "Request failed schema validation", validationErrors: NonEmptyList[ValidationError]): SchemaValidationError =
     SchemaValidationError(message, ErrorCode.SchemaValidation, validationErrors)
 

--- a/test/controllers/actions/AuthActionSpec.scala
+++ b/test/controllers/actions/AuthActionSpec.scala
@@ -22,6 +22,7 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.Json
 import play.api.mvc.Action
 import play.api.mvc.AnyContent
 import play.api.mvc.BodyParsers
@@ -301,6 +302,10 @@ class AuthActionSpec extends AnyFreeSpec with Matchers with MockitoSugar {
       val result     = controller.get()(FakeRequest())
 
       status(result) mustEqual UNAUTHORIZED
+      contentAsJson(result) mustEqual Json.obj(
+        "message" -> "Failed to authorise user: Bearer token not supplied",
+        "code"    -> "UNAUTHORIZED"
+      )
     }
   }
 
@@ -324,7 +329,10 @@ class AuthActionSpec extends AnyFreeSpec with Matchers with MockitoSugar {
       val result     = controller.get()(FakeRequest())
 
       status(result) mustEqual INTERNAL_SERVER_ERROR
-      contentAsString(result) mustEqual ""
+      contentAsJson(result) mustEqual Json.obj(
+        "message" -> "Internal server error",
+        "code"    -> "INTERNAL_SERVER_ERROR"
+      )
     }
   }
 

--- a/test/v2/controllers/actions/AuthNewEnrolmentOnlyActionSpec.scala
+++ b/test/v2/controllers/actions/AuthNewEnrolmentOnlyActionSpec.scala
@@ -314,6 +314,10 @@ class AuthNewEnrolmentOnlyActionSpec extends AnyFreeSpec with Matchers with Mock
       val result     = controller.get()(FakeRequest())
 
       status(result) mustEqual UNAUTHORIZED
+      contentAsJson(result) mustEqual Json.obj(
+        "message" -> "Failed to authorise user: Bearer token not supplied",
+        "code"    -> "UNAUTHORIZED"
+      )
     }
   }
 
@@ -337,7 +341,10 @@ class AuthNewEnrolmentOnlyActionSpec extends AnyFreeSpec with Matchers with Mock
       val result     = controller.get()(FakeRequest())
 
       status(result) mustEqual INTERNAL_SERVER_ERROR
-      contentAsString(result) mustEqual ""
+      contentAsJson(result) mustEqual Json.obj(
+        "message" -> "Internal server error",
+        "code"    -> "INTERNAL_SERVER_ERROR"
+      )
     }
   }
 }


### PR DESCRIPTION
Currently we are returning 500 from our service when the auth service returns an error response. The issue is that in the response, the reason for the failure is being captured and returned to the user. This PR logs the exception returned rather than including it in the internal server error response.