### PR TITLE
CTCP-773: Add endpoint to get a message for a trader

### DIFF
--- a/app/controllers/DepartureMessagesController.scala
+++ b/app/controllers/DepartureMessagesController.scala
@@ -16,13 +16,16 @@
 
 package controllers
 
-import java.time.OffsetDateTime
+import com.google.inject.ImplementedBy
+import com.google.inject.Singleton
 
+import java.time.OffsetDateTime
 import com.kenshoo.play.metrics.Metrics
 import connectors.DepartureMessageConnector
 import controllers.actions.AuthAction
 import controllers.actions.ValidateAcceptJsonHeaderAction
 import controllers.actions.ValidateDepartureMessageAction
+
 import javax.inject.Inject
 import metrics.HasActionMetrics
 import metrics.MetricsKeys
@@ -46,6 +49,14 @@ import scala.concurrent.ExecutionContext
 import scala.xml.NodeSeq
 import controllers.actions.AnalyseMessageActionProvider
 
+@ImplementedBy(classOf[DepartureMessagesController])
+trait V1DepartureMessagesController {
+
+  def getDepartureMessage(departureId: DepartureId, messageId: MessageId): Action[AnyContent]
+
+}
+
+@Singleton
 class DepartureMessagesController @Inject() (
   cc: ControllerComponents,
   authAction: AuthAction,
@@ -58,7 +69,8 @@ class DepartureMessagesController @Inject() (
     extends BackendController(cc)
     with HasActionMetrics
     with HttpErrorFunctions
-    with ResponseHelper {
+    with ResponseHelper
+    with V1DepartureMessagesController {
 
   import MetricsKeys.Endpoints._
 
@@ -86,7 +98,7 @@ class DepartureMessagesController @Inject() (
                                 request.body
                               )
                             )
-                          ).withHeaders(LOCATION -> routes.DepartureMessagesController.getDepartureMessage(departureId, messageId).urlWithContext)
+                          ).withHeaders(LOCATION -> routing.routes.DeparturesRouter.getMessage(departureId.toString, messageId.toString).urlWithContext)
                         case None =>
                           InternalServerError
                       }

--- a/app/models/response/HateoasDepartureMessagesPostResponseMessage.scala
+++ b/app/models/response/HateoasDepartureMessagesPostResponseMessage.scala
@@ -28,7 +28,7 @@ import scala.xml.NodeSeq
 object HateoasDepartureMessagesPostResponseMessage {
 
   def apply(departureId: DepartureId, messageId: MessageId, messageType: String, message: NodeSeq): JsObject = {
-    val messageUrl   = routes.DepartureMessagesController.getDepartureMessage(departureId, messageId).urlWithContext
+    val messageUrl   = routing.routes.DeparturesRouter.getMessage(departureId.toString, messageId.toString).urlWithContext
     val departureUrl = routes.DeparturesController.getDeparture(departureId).urlWithContext
 
     Json.obj(

--- a/app/models/response/HateoasDepartureResponseMessage.scala
+++ b/app/models/response/HateoasDepartureResponseMessage.scala
@@ -27,7 +27,7 @@ import utils.CallOps._
 object HateoasDepartureResponseMessage {
 
   def apply(departureId: DepartureId, messageId: MessageId, m: MovementMessage): JsObject = {
-    val departureUrl = routes.DepartureMessagesController.getDepartureMessage(departureId, messageId).urlWithContext
+    val departureUrl = routing.routes.DeparturesRouter.getMessage(departureId.toString, messageId.toString).urlWithContext
     val messageUrl   = routes.DeparturesController.getDeparture(departureId).urlWithContext
 
     Json.obj(

--- a/app/routing/DeparturesRouter.scala
+++ b/app/routing/DeparturesRouter.scala
@@ -22,8 +22,8 @@ import akka.util.ByteString
 import com.google.inject.Inject
 import controllers.V1DepartureMessagesController
 import controllers.V1DeparturesController
-import models.domain.DepartureId
-import models.domain.MessageId
+import models.domain.{DepartureId => V1DepartureId}
+import models.domain.{MessageId => V1MessageId}
 import play.api.mvc.Action
 import play.api.mvc.BaseController
 import play.api.mvc.ControllerComponents
@@ -31,7 +31,8 @@ import play.api.mvc.PathBindable
 import v2.controllers.V2DeparturesController
 import v2.controllers.stream.StreamingParsers
 import v2.models.Bindings._
-import v2.models.MovementId
+import v2.models.{DepartureId => V2DepartureId}
+import v2.models.{MessageId => V2MessageId}
 
 class DeparturesRouter @Inject() (
   val controllerComponents: ControllerComponents,
@@ -52,16 +53,16 @@ class DeparturesRouter @Inject() (
   def getMessage(departureId: String, messageId: String): Action[Source[ByteString, _]] = route {
     case Some(VersionedRouting.VERSION_2_ACCEPT_HEADER_VALUE) =>
       (for {
-        convertedDepartureId <- implicitly[PathBindable[MovementId]].bind("departureId", departureId)
-        convertedMovementId  <- implicitly[PathBindable[v2.models.MessageId]].bind("messageId", messageId)
+        convertedDepartureId <- implicitly[PathBindable[V2DepartureId]].bind("departureId", departureId)
+        convertedMovementId  <- implicitly[PathBindable[V2MessageId]].bind("messageId", messageId)
       } yield (convertedDepartureId, convertedMovementId)).fold(
         bindingFailureAction(_),
         converted => v2Departures.getMessage(converted._1, converted._2)
       )
     case _ =>
       (for {
-        convertedDepartureId <- implicitly[PathBindable[DepartureId]].bind("departureId", departureId)
-        convertedMovementId  <- implicitly[PathBindable[MessageId]].bind("messageId", messageId)
+        convertedDepartureId <- implicitly[PathBindable[V1DepartureId]].bind("departureId", departureId)
+        convertedMovementId  <- implicitly[PathBindable[V1MessageId]].bind("messageId", messageId)
       } yield (convertedDepartureId, convertedMovementId)).fold(
         bindingFailureAction(_),
         converted => v1DepartureMessages.getDepartureMessage(converted._1, converted._2)

--- a/app/routing/DeparturesRouter.scala
+++ b/app/routing/DeparturesRouter.scala
@@ -54,16 +54,16 @@ class DeparturesRouter @Inject() (
     case Some(VersionedRouting.VERSION_2_ACCEPT_HEADER_VALUE) =>
       (for {
         convertedDepartureId <- implicitly[PathBindable[V2DepartureId]].bind("departureId", departureId)
-        convertedMovementId  <- implicitly[PathBindable[V2MessageId]].bind("messageId", messageId)
-      } yield (convertedDepartureId, convertedMovementId)).fold(
+        convertedMessageId   <- implicitly[PathBindable[V2MessageId]].bind("messageId", messageId)
+      } yield (convertedDepartureId, convertedMessageId)).fold(
         bindingFailureAction(_),
         converted => v2Departures.getMessage(converted._1, converted._2)
       )
     case _ =>
       (for {
         convertedDepartureId <- implicitly[PathBindable[V1DepartureId]].bind("departureId", departureId)
-        convertedMovementId  <- implicitly[PathBindable[V1MessageId]].bind("messageId", messageId)
-      } yield (convertedDepartureId, convertedMovementId)).fold(
+        convertedMessageId   <- implicitly[PathBindable[V1MessageId]].bind("messageId", messageId)
+      } yield (convertedDepartureId, convertedMessageId)).fold(
         bindingFailureAction(_),
         converted => v1DepartureMessages.getDepartureMessage(converted._1, converted._2)
       )

--- a/app/routing/DeparturesRouter.scala
+++ b/app/routing/DeparturesRouter.scala
@@ -25,14 +25,13 @@ import controllers.V1DeparturesController
 import models.domain.DepartureId
 import models.domain.MessageId
 import play.api.mvc.Action
-import play.api.mvc.AnyContent
 import play.api.mvc.BaseController
 import play.api.mvc.ControllerComponents
 import play.api.mvc.PathBindable
 import v2.controllers.V2DeparturesController
 import v2.controllers.stream.StreamingParsers
-import v2.models.MovementId
 import v2.models.Bindings._
+import v2.models.MovementId
 
 class DeparturesRouter @Inject() (
   val controllerComponents: ControllerComponents,

--- a/app/routing/VersionedRouting.scala
+++ b/app/routing/VersionedRouting.scala
@@ -30,6 +30,12 @@ import v2.models.errors.PresentationError
 
 import scala.concurrent.Future
 
+object VersionedRouting {
+
+  val VERSION_2_ACCEPT_HEADER_VALUE = "application/vnd.hmrc.2.0+json"
+
+}
+
 trait VersionedRouting {
   self: BaseController with StreamingParsers =>
 
@@ -59,6 +65,15 @@ trait VersionedRouting {
               )
             )
           }
+    }
+
+  // This simulates what Play will do if a binding fails, with the addition of the "code" field
+  // that we use elsewhere.
+  def bindingFailureAction(message: String)(implicit materializer: Materializer): Action[Source[ByteString, _]] =
+    Action.async(streamFromMemory) {
+      implicit request =>
+        request.body.runWith(Sink.ignore)
+        Future.successful(Status(BAD_REQUEST)(Json.toJson(PresentationError.bindingBadRequestError(message))))
     }
 
 }

--- a/app/v2/connectors/AuditingConnector.scala
+++ b/app/v2/connectors/AuditingConnector.scala
@@ -26,7 +26,6 @@ import metrics.HasMetrics
 import metrics.MetricsKeys
 import play.api.Logging
 import play.api.http.HeaderNames
-import play.api.http.MimeTypes
 import play.api.http.Status.ACCEPTED
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.HttpReads.Implicits._

--- a/app/v2/connectors/AuditingConnector.scala
+++ b/app/v2/connectors/AuditingConnector.scala
@@ -26,12 +26,8 @@ import metrics.HasMetrics
 import metrics.MetricsKeys
 import play.api.Logging
 import play.api.http.HeaderNames
-import play.api.http.Status.ACCEPTED
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.http.HttpReads.Implicits._
-import uk.gov.hmrc.http.HttpResponse
 import uk.gov.hmrc.http.StringContextOps
-import uk.gov.hmrc.http.UpstreamErrorResponse
 import uk.gov.hmrc.http.client.HttpClientV2
 import v2.models.AuditType
 
@@ -60,14 +56,7 @@ class AuditingConnectorImpl @Inject() (httpClient: HttpClientV2, appConfig: AppC
           .post(url"$url")
           .addHeaders(HeaderNames.CONTENT_TYPE -> contentType)
           .withBody(source)
-          .execute[HttpResponse]
-          .flatMap {
-            response =>
-              response.status match {
-                case ACCEPTED => Future.successful(())
-                case _        => Future.failed(UpstreamErrorResponse(response.body, response.status))
-              }
-          }
+          .executeAccepted
     }
 
 }

--- a/app/v2/connectors/PersistenceConnector.scala
+++ b/app/v2/connectors/PersistenceConnector.scala
@@ -39,7 +39,7 @@ import v2.models.EORINumber
 import v2.models.responses.DeclarationResponse
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import v2.models.MessageId
-import v2.models.MovementId
+import v2.models.DepartureId
 import v2.models.responses.MessageResponse
 
 import scala.concurrent.ExecutionContext
@@ -53,7 +53,7 @@ trait PersistenceConnector {
     ec: ExecutionContext
   ): Future[DeclarationResponse]
 
-  def getDepartureMessage(eori: EORINumber, departureId: MovementId, messageId: MessageId)(implicit
+  def getDepartureMessage(eori: EORINumber, departureId: DepartureId, messageId: MessageId)(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
   ): Future[MessageResponse]
@@ -98,7 +98,7 @@ class PersistenceConnectorImpl @Inject() (httpClientV2: HttpClientV2, appConfig:
           }
     }
 
-  override def getDepartureMessage(eori: EORINumber, departureId: MovementId, messageId: MessageId)(implicit
+  override def getDepartureMessage(eori: EORINumber, departureId: DepartureId, messageId: MessageId)(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
   ): Future[MessageResponse] = {

--- a/app/v2/connectors/PersistenceConnector.scala
+++ b/app/v2/connectors/PersistenceConnector.scala
@@ -29,17 +29,15 @@ import play.api.Logging
 import play.api.http.HeaderNames
 import play.api.http.MimeTypes
 import play.api.http.Status.OK
-import play.api.libs.json.JsResult
-import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.HttpResponse
 import uk.gov.hmrc.http.StringContextOps
-import uk.gov.hmrc.http.UpstreamErrorResponse
-import v2.models.EORINumber
-import v2.models.responses.DeclarationResponse
-import uk.gov.hmrc.http.HttpReads.Implicits._
-import v2.models.MessageId
+import uk.gov.hmrc.http.client.HttpClientV2
 import v2.models.DepartureId
+import v2.models.EORINumber
+import v2.models.MessageId
+import v2.models.responses.DeclarationResponse
 import v2.models.responses.MessageResponse
 
 import scala.concurrent.ExecutionContext
@@ -73,7 +71,7 @@ class PersistenceConnectorImpl @Inject() (httpClientV2: HttpClientV2, appConfig:
   ): Future[DeclarationResponse] =
     withMetricsTimerAsync(MetricsKeys.ValidatorBackend.Post) {
       _ =>
-        val url = appConfig.movementsUrl.withPath(movementsPostDeperatureDeclaration(eori))
+        val url = appConfig.movementsUrl.withPath(movementsPostDepartureDeclaration(eori))
 
         httpClientV2
           .post(url"$url")
@@ -83,17 +81,8 @@ class PersistenceConnectorImpl @Inject() (httpClientV2: HttpClientV2, appConfig:
           .flatMap {
             response =>
               response.status match {
-                case OK =>
-                  response.json
-                    .validate[DeclarationResponse]
-                    .map(
-                      result => Future.successful(result)
-                    )
-                    .recoverTotal(
-                      error => Future.failed(JsResult.Exception(error))
-                    )
-                case _ =>
-                  Future.failed(UpstreamErrorResponse(response.body, response.status))
+                case OK => response.as[DeclarationResponse]
+                case _  => response.error
               }
           }
     }
@@ -111,17 +100,8 @@ class PersistenceConnectorImpl @Inject() (httpClientV2: HttpClientV2, appConfig:
       .flatMap {
         response =>
           response.status match {
-            case OK =>
-              response.json
-                .validate[MessageResponse]
-                .map(
-                  result => Future.successful(result)
-                )
-                .recoverTotal(
-                  error => Future.failed(JsResult.Exception(error))
-                )
-            case _ =>
-              Future.failed(UpstreamErrorResponse(response.body, response.status))
+            case OK => response.as[MessageResponse]
+            case _  => response.error
           }
       }
   }

--- a/app/v2/connectors/RouterConnector.scala
+++ b/app/v2/connectors/RouterConnector.scala
@@ -35,7 +35,7 @@ import uk.gov.hmrc.http.StringContextOps
 import uk.gov.hmrc.http.UpstreamErrorResponse
 import v2.models.EORINumber
 import v2.models.MessageId
-import v2.models.MovementId
+import v2.models.DepartureId
 import v2.models.request.MessageType
 import uk.gov.hmrc.http.HttpReads.Implicits._
 
@@ -45,7 +45,7 @@ import scala.concurrent.Future
 @ImplementedBy(classOf[RouterConnectorImpl])
 trait RouterConnector {
 
-  def post(messageType: MessageType, eoriNumber: EORINumber, movementId: MovementId, messageId: MessageId, body: Source[ByteString, _])(implicit
+  def post(messageType: MessageType, eoriNumber: EORINumber, movementId: DepartureId, messageId: MessageId, body: Source[ByteString, _])(implicit
     ec: ExecutionContext,
     hc: HeaderCarrier
   ): Future[Unit]
@@ -58,7 +58,7 @@ class RouterConnectorImpl @Inject() (val metrics: Metrics, appConfig: AppConfig,
     with HasMetrics
     with Logging {
 
-  override def post(messageType: MessageType, eoriNumber: EORINumber, movementId: MovementId, messageId: MessageId, body: Source[ByteString, _])(implicit
+  override def post(messageType: MessageType, eoriNumber: EORINumber, movementId: DepartureId, messageId: MessageId, body: Source[ByteString, _])(implicit
     ec: ExecutionContext,
     hc: HeaderCarrier
   ): Future[Unit] =

--- a/app/v2/connectors/RouterConnector.scala
+++ b/app/v2/connectors/RouterConnector.scala
@@ -27,17 +27,13 @@ import metrics.MetricsKeys
 import play.api.Logging
 import play.api.http.HeaderNames
 import play.api.http.MimeTypes
-import play.api.http.Status.ACCEPTED
-import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.http.HttpResponse
 import uk.gov.hmrc.http.StringContextOps
-import uk.gov.hmrc.http.UpstreamErrorResponse
+import uk.gov.hmrc.http.client.HttpClientV2
+import v2.models.DepartureId
 import v2.models.EORINumber
 import v2.models.MessageId
-import v2.models.DepartureId
 import v2.models.request.MessageType
-import uk.gov.hmrc.http.HttpReads.Implicits._
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -70,14 +66,7 @@ class RouterConnectorImpl @Inject() (val metrics: Metrics, appConfig: AppConfig,
           .post(url"$url")
           .addHeaders(HeaderNames.CONTENT_TYPE -> MimeTypes.XML)
           .withBody(body)
-          .execute[HttpResponse]
-          .flatMap {
-            response =>
-              response.status match {
-                case ACCEPTED => Future.successful(())
-                case _        => Future.failed(UpstreamErrorResponse(response.body, response.status))
-              }
-          }
+          .executeAccepted
     }
 
 }

--- a/app/v2/connectors/V2BaseConnector.scala
+++ b/app/v2/connectors/V2BaseConnector.scala
@@ -34,6 +34,9 @@ trait V2BaseConnector extends HttpErrorFunctions {
   protected def movementsPostDeperatureDeclaration(eoriNumber: EORINumber): UrlPath =
     UrlPath.parse(s"$movementsBaseRoute/traders/${eoriNumber.value}/movements/departures/")
 
+  protected def movementsGetDepartureMessage(eoriNumber: EORINumber, departureId: MovementId, messageId: MessageId): UrlPath =
+    UrlPath.parse(s"$movementsBaseRoute/traders/${eoriNumber.value}/movements/departures/${departureId.value}/messages/${messageId.value}/")
+
   protected def routerBaseRoute: String = "/transit-movements-router"
 
   protected def routerRoute(eoriNumber: EORINumber, messageType: MessageType, movementId: MovementId, messageId: MessageId): UrlPath =

--- a/app/v2/connectors/V2BaseConnector.scala
+++ b/app/v2/connectors/V2BaseConnector.scala
@@ -20,7 +20,7 @@ import io.lemonlabs.uri.UrlPath
 import uk.gov.hmrc.http.HttpErrorFunctions
 import v2.models.AuditType
 import v2.models.EORINumber
-import v2.models.MovementId
+import v2.models.DepartureId
 import v2.models.MessageId
 import v2.models.request.MessageType
 
@@ -34,12 +34,12 @@ trait V2BaseConnector extends HttpErrorFunctions {
   protected def movementsPostDeperatureDeclaration(eoriNumber: EORINumber): UrlPath =
     UrlPath.parse(s"$movementsBaseRoute/traders/${eoriNumber.value}/movements/departures/")
 
-  protected def movementsGetDepartureMessage(eoriNumber: EORINumber, departureId: MovementId, messageId: MessageId): UrlPath =
+  protected def movementsGetDepartureMessage(eoriNumber: EORINumber, departureId: DepartureId, messageId: MessageId): UrlPath =
     UrlPath.parse(s"$movementsBaseRoute/traders/${eoriNumber.value}/movements/departures/${departureId.value}/messages/${messageId.value}/")
 
   protected def routerBaseRoute: String = "/transit-movements-router"
 
-  protected def routerRoute(eoriNumber: EORINumber, messageType: MessageType, movementId: MovementId, messageId: MessageId): UrlPath =
+  protected def routerRoute(eoriNumber: EORINumber, messageType: MessageType, movementId: DepartureId, messageId: MessageId): UrlPath =
     UrlPath.parse(s"$routerBaseRoute/traders/${eoriNumber.value}/movements/${messageType.movementType}/${movementId.value}/messages/${messageId.value}/")
 
   protected def auditingBaseRoute: String = "/transit-movements-auditing"

--- a/app/v2/connectors/V2BaseConnector.scala
+++ b/app/v2/connectors/V2BaseConnector.scala
@@ -16,38 +16,105 @@
 
 package v2.connectors
 
+import akka.stream.Materializer
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
 import io.lemonlabs.uri.UrlPath
+import play.api.http.Status.ACCEPTED
+import play.api.http.Status.OK
+import play.api.libs.json.JsResult
+import play.api.libs.json.Reads
 import uk.gov.hmrc.http.HttpErrorFunctions
+import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.HttpResponse
+import uk.gov.hmrc.http.UpstreamErrorResponse
+import uk.gov.hmrc.http.client.RequestBuilder
 import v2.models.AuditType
 import v2.models.EORINumber
 import v2.models.DepartureId
 import v2.models.MessageId
 import v2.models.request.MessageType
 
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
 trait V2BaseConnector extends HttpErrorFunctions {
 
-  protected def validationRoute(messageType: MessageType): UrlPath =
+  def validationRoute(messageType: MessageType): UrlPath =
     UrlPath.parse(s"/transit-movements-validator/messages/${messageType.code}/validation")
 
-  protected def movementsBaseRoute: String = "/transit-movements"
+  def movementsBaseRoute: String = "/transit-movements"
 
-  protected def movementsPostDeperatureDeclaration(eoriNumber: EORINumber): UrlPath =
+  def movementsPostDepartureDeclaration(eoriNumber: EORINumber): UrlPath =
     UrlPath.parse(s"$movementsBaseRoute/traders/${eoriNumber.value}/movements/departures/")
 
-  protected def movementsGetDepartureMessage(eoriNumber: EORINumber, departureId: DepartureId, messageId: MessageId): UrlPath =
+  def movementsGetDepartureMessage(eoriNumber: EORINumber, departureId: DepartureId, messageId: MessageId): UrlPath =
     UrlPath.parse(s"$movementsBaseRoute/traders/${eoriNumber.value}/movements/departures/${departureId.value}/messages/${messageId.value}/")
 
-  protected def routerBaseRoute: String = "/transit-movements-router"
+  def routerBaseRoute: String = "/transit-movements-router"
 
-  protected def routerRoute(eoriNumber: EORINumber, messageType: MessageType, movementId: DepartureId, messageId: MessageId): UrlPath =
+  def routerRoute(eoriNumber: EORINumber, messageType: MessageType, movementId: DepartureId, messageId: MessageId): UrlPath =
     UrlPath.parse(s"$routerBaseRoute/traders/${eoriNumber.value}/movements/${messageType.movementType}/${movementId.value}/messages/${messageId.value}/")
 
-  protected def auditingBaseRoute: String = "/transit-movements-auditing"
+  def auditingBaseRoute: String = "/transit-movements-auditing"
 
-  protected def auditingRoute(auditType: AuditType): UrlPath =
+  def auditingRoute(auditType: AuditType): UrlPath =
     UrlPath.parse(s"$auditingBaseRoute/audit/${auditType.name}")
 
-  protected def conversionRoute(messageType: MessageType): UrlPath =
+  def conversionRoute(messageType: MessageType): UrlPath =
     UrlPath.parse(s"/transit-movements-converter/messages/${messageType.code}")
+
+  implicit class HttpResponseHelpers(response: HttpResponse) {
+
+    def as[A](implicit reads: Reads[A]): Future[A] =
+      response.json
+        .validate[A]
+        .map(
+          result => Future.successful(result)
+        )
+        .recoverTotal(
+          error => Future.failed(JsResult.Exception(error))
+        )
+
+    def errorFromStream[A](implicit m: Materializer, ec: ExecutionContext): Future[A] =
+      response.bodyAsSource
+        .reduce(_ ++ _)
+        .map(_.utf8String)
+        .runWith(Sink.head)
+        .flatMap(
+          result => Future.failed(UpstreamErrorResponse(result, response.status))
+        )
+
+    def error[A]: Future[A] =
+      Future.failed(UpstreamErrorResponse(response.body, response.status))
+
+  }
+
+  implicit class RequestBuilderHelpers(requestBuilder: RequestBuilder) {
+
+    def executeAccepted(implicit ec: ExecutionContext): Future[Unit] =
+      requestBuilder
+        .execute[HttpResponse]
+        .flatMap {
+          response =>
+            response.status match {
+              case ACCEPTED => Future.successful(())
+              case _        => response.error
+            }
+        }
+
+    def executeAsStream(implicit m: Materializer, ec: ExecutionContext): Future[Source[ByteString, _]] =
+      requestBuilder
+        .stream[HttpResponse]
+        .flatMap {
+          response =>
+            response.status match {
+              case OK => Future.successful(response.bodyAsSource)
+              case _  => response.errorFromStream
+            }
+        }
+
+  }
 
 }

--- a/app/v2/controllers/ErrorTranslator.scala
+++ b/app/v2/controllers/ErrorTranslator.scala
@@ -56,6 +56,8 @@ trait ErrorTranslator {
   implicit val persistenceErrorConverter = new Converter[PersistenceError] {
 
     def convert(persistenceError: PersistenceError): PresentationError = persistenceError match {
+      case PersistenceError.MessageNotFound(movement, message) =>
+        PresentationError.notFoundError(s"Message with ID ${message.value} for movement ${movement.value} was not found")
       case err: PersistenceError.UnexpectedError => PresentationError.internalServiceError(cause = err.thr)
     }
   }

--- a/app/v2/controllers/V2DeparturesController.scala
+++ b/app/v2/controllers/V2DeparturesController.scala
@@ -46,7 +46,7 @@ import v2.controllers.stream.StreamingParsers
 import v2.models.AuditType
 import v2.models.errors.PresentationError
 import v2.models.MessageId
-import v2.models.MovementId
+import v2.models.DepartureId
 import v2.models.request.MessageType
 import v2.models.responses.DeclarationResponse
 import v2.models.responses.hateoas.HateoasDepartureDeclarationResponse
@@ -65,7 +65,7 @@ trait V2DeparturesController {
 
   def submitDeclaration(): Action[Source[ByteString, _]]
 
-  def getMessage(departureId: MovementId, messageId: MessageId): Action[AnyContent]
+  def getMessage(departureId: DepartureId, messageId: MessageId): Action[AnyContent]
 
 }
 
@@ -175,7 +175,7 @@ class V2DeparturesControllerImpl @Inject() (
         .asPresentation
     } yield declarationResult
 
-  def getMessage(departureId: MovementId, messageId: MessageId): Action[AnyContent] =
+  def getMessage(departureId: DepartureId, messageId: MessageId): Action[AnyContent] =
     authActionNewEnrolmentOnly.async {
       implicit request =>
         implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequest(request)

--- a/app/v2/controllers/V2DeparturesController.scala
+++ b/app/v2/controllers/V2DeparturesController.scala
@@ -32,6 +32,7 @@ import play.api.http.MimeTypes
 import play.api.libs.Files.TemporaryFileCreator
 import play.api.libs.json.Json
 import play.api.mvc.Action
+import play.api.mvc.AnyContent
 import play.api.mvc.BaseController
 import play.api.mvc.ControllerComponents
 import play.api.mvc.Result
@@ -44,6 +45,8 @@ import v2.controllers.request.AuthenticatedRequest
 import v2.controllers.stream.StreamingParsers
 import v2.models.AuditType
 import v2.models.errors.PresentationError
+import v2.models.MessageId
+import v2.models.MovementId
 import v2.models.request.MessageType
 import v2.models.responses.DeclarationResponse
 import v2.models.responses.hateoas.HateoasDepartureDeclarationResponse
@@ -56,10 +59,14 @@ import com.codahale.metrics.Counter
 
 import scala.concurrent.Future
 
+import scala.concurrent.Future
+
 @ImplementedBy(classOf[V2DeparturesControllerImpl])
 trait V2DeparturesController {
 
   def submitDeclaration(): Action[Source[ByteString, _]]
+
+  def getMessage(departureId: MovementId, messageId: MessageId): Action[AnyContent]
 
 }
 
@@ -168,4 +175,11 @@ class V2DeparturesControllerImpl @Inject() (
         .send(MessageType.DepartureDeclaration, request.eoriNumber, declarationResult.departureId, declarationResult.messageId, fileSource)
         .asPresentation
     } yield declarationResult
+
+  def getMessage(departureId: MovementId, messageId: MessageId): Action[AnyContent] =
+    authActionNewEnrolmentOnly.async {
+      implicit request =>
+        Future.successful(Ok)
+    }
+
 }

--- a/app/v2/models/AuditType.scala
+++ b/app/v2/models/AuditType.scala
@@ -23,4 +23,8 @@ object AuditType {
   // IE015
   case object DeclarationData extends AuditType("DeclarationData")
 
+  val values: Seq[AuditType] = Seq(
+    DeclarationData
+  )
+
 }

--- a/app/v2/models/Bindings.scala
+++ b/app/v2/models/Bindings.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.models
+
+import play.api.mvc.PathBindable
+
+object Bindings {
+
+  val idPattern = "^[0-9a-f]{16}$".r
+
+  def hexBinding[T](bindFn: String => T, unbindFn: T => String): PathBindable[T] = new PathBindable[T] {
+
+    override def bind(key: String, value: String): Either[String, T] =
+      if (idPattern.pattern.matcher(value).matches()) Right(bindFn(value))
+      else Left(s"$key: Value $value is not a 16 character hexadecimal string")
+
+    override def unbind(key: String, value: T): String = unbindFn(value)
+  }
+
+  implicit val messageIdBinding  = hexBinding[MessageId](MessageId.apply, _.value)
+  implicit val movementIdBinding = hexBinding[MovementId](MovementId.apply, _.value)
+
+}

--- a/app/v2/models/Bindings.scala
+++ b/app/v2/models/Bindings.scala
@@ -32,6 +32,6 @@ object Bindings {
   }
 
   implicit val messageIdBinding  = hexBinding[MessageId](MessageId.apply, _.value)
-  implicit val movementIdBinding = hexBinding[MovementId](MovementId.apply, _.value)
+  implicit val movementIdBinding = hexBinding[DepartureId](DepartureId.apply, _.value)
 
 }

--- a/app/v2/models/DepartureId.scala
+++ b/app/v2/models/DepartureId.scala
@@ -19,8 +19,8 @@ package v2.models
 import play.api.libs.json.Format
 import play.api.libs.json.Json
 
-object MovementId {
-  implicit lazy val movementIdFormat: Format[MovementId] = Json.valueFormat[MovementId]
+object DepartureId {
+  implicit lazy val departureIdFormat: Format[DepartureId] = Json.valueFormat[DepartureId]
 }
 
-case class MovementId(value: String) extends AnyVal
+case class DepartureId(value: String) extends AnyVal

--- a/app/v2/models/errors/PersistenceError.scala
+++ b/app/v2/models/errors/PersistenceError.scala
@@ -17,11 +17,11 @@
 package v2.models.errors
 
 import v2.models.MessageId
-import v2.models.MovementId
+import v2.models.DepartureId
 
 sealed trait PersistenceError
 
 object PersistenceError {
-  case class MessageNotFound(movementId: MovementId, messageId: MessageId) extends PersistenceError
-  case class UnexpectedError(thr: Option[Throwable] = None)                extends PersistenceError
+  case class MessageNotFound(movementId: DepartureId, messageId: MessageId) extends PersistenceError
+  case class UnexpectedError(thr: Option[Throwable] = None)                 extends PersistenceError
 }

--- a/app/v2/models/request/MessageType.scala
+++ b/app/v2/models/request/MessageType.scala
@@ -16,6 +16,12 @@
 
 package v2.models.request
 
+import play.api.libs.json.JsError
+import play.api.libs.json.JsString
+import play.api.libs.json.JsSuccess
+import play.api.libs.json.Reads
+import play.api.libs.json.Writes
+
 sealed trait MessageType {
   def code: String
   def movementType: String
@@ -27,4 +33,21 @@ sealed abstract class DepartureMessageType(val code: String) extends MessageType
 
 object MessageType {
   case object DepartureDeclaration extends DepartureMessageType("IE015")
+
+  val values: Seq[MessageType] = Seq(
+    DepartureDeclaration
+  )
+
+  def find(code: String): Option[MessageType] =
+    values.find(_.code == code)
+
+  implicit val messageTypeReads: Reads[MessageType] = Reads {
+    case JsString(value) => find(value).map(JsSuccess(_)).getOrElse(JsError())
+    case _               => JsError()
+  }
+
+  implicit val messageTypeWrites: Writes[MessageType] = Writes {
+    obj => JsString(obj.code)
+  }
+
 }

--- a/app/v2/models/responses/DeclarationResponse.scala
+++ b/app/v2/models/responses/DeclarationResponse.scala
@@ -19,10 +19,10 @@ package v2.models.responses
 import play.api.libs.json.Json
 import play.api.libs.json.OFormat
 import v2.models.MessageId
-import v2.models.MovementId
+import v2.models.DepartureId
 
 object DeclarationResponse {
   implicit lazy val declarationResponseFormat: OFormat[DeclarationResponse] = Json.format[DeclarationResponse]
 }
 
-case class DeclarationResponse(departureId: MovementId, messageId: MessageId)
+case class DeclarationResponse(departureId: DepartureId, messageId: MessageId)

--- a/app/v2/models/responses/MessageResponse.scala
+++ b/app/v2/models/responses/MessageResponse.scala
@@ -14,14 +14,25 @@
  * limitations under the License.
  */
 
-package v2.models.errors
+package v2.models.responses
 
+import play.api.libs.json.Json
 import v2.models.MessageId
-import v2.models.MovementId
+import v2.models.request.MessageType
 
-sealed trait PersistenceError
+import java.net.URI
+import java.time.OffsetDateTime
 
-object PersistenceError {
-  case class MessageNotFound(movementId: MovementId, messageId: MessageId) extends PersistenceError
-  case class UnexpectedError(thr: Option[Throwable] = None)                extends PersistenceError
+object MessageResponse {
+  implicit lazy val messageResponseFormat = Json.format[MessageResponse]
 }
+
+case class MessageResponse(
+  id: MessageId,
+  received: OffsetDateTime,
+  generated: OffsetDateTime,
+  messageType: MessageType,
+  triggerId: Option[MessageId],
+  url: Option[URI],
+  body: Option[String]
+)

--- a/app/v2/models/responses/hateoas/HateoasDepartureDeclarationResponse.scala
+++ b/app/v2/models/responses/hateoas/HateoasDepartureDeclarationResponse.scala
@@ -16,23 +16,21 @@
 
 package v2.models.responses.hateoas
 
-import controllers.routes
-import models.domain.DepartureId
 import play.api.libs.json.JsObject
 import play.api.libs.json.Json
-import utils.CallOps.CallOps
-import v2.models.MovementId
+import v2.models.DepartureId
 
 object HateoasDepartureDeclarationResponse {
 
-  def messageUrl(movementId: MovementId) =
-    // TODO: Fix when we do this route, as right now it only accepts an int.
-    routes.DepartureMessagesController.sendMessageDownstream(DepartureId(123)).urlWithContext
+  // TODO: Fix when we do this route, as right now it only accepts an int.
+  def messageUrl(departureId: DepartureId) =
+    s"/customs/transits/movements/departures/${departureId.value}/messages"
 
   // TODO: Fix when we do this route, as right now it only accepts an int.
-  def departureUrl(movementId: MovementId) = routes.DeparturesController.getDeparture(DepartureId(123)).urlWithContext
+  def departureUrl(departureId: DepartureId) =
+    s"/customs/transits/movements/departures/${departureId.value}"
 
-  def apply(departureId: MovementId): JsObject =
+  def apply(departureId: DepartureId): JsObject =
     Json.obj(
       "_links" -> Json.obj(
         "self" -> Json.obj("href" -> departureUrl(departureId))

--- a/app/v2/models/responses/hateoas/HateoasDepartureMessageResponse.scala
+++ b/app/v2/models/responses/hateoas/HateoasDepartureMessageResponse.scala
@@ -19,7 +19,7 @@ package v2.models.responses.hateoas
 import play.api.libs.json.JsObject
 import play.api.libs.json.Json
 import v2.models.MessageId
-import v2.models.MovementId
+import v2.models.DepartureId
 import v2.models.responses.MessageResponse
 
 object HateoasDepartureMessageResponse {
@@ -28,15 +28,15 @@ object HateoasDepartureMessageResponse {
     if (routing.routes.DeparturesRouter.submitDeclaration().url.startsWith("/customs/transits")) ""
     else "/customs/transits"
 
-  def selfUrl(departureId: MovementId, messageId: MessageId) =
+  def selfUrl(departureId: DepartureId, messageId: MessageId) =
     prefix + routing.routes.DeparturesRouter.getMessage(departureId.value, messageId.value).url
 
   // TODO: When we do the departure endpoint, this needs updating
-  def departureUrl(departureId: MovementId) =
+  def departureUrl(departureId: DepartureId) =
     s"/customs/transits/movements/departures/${departureId.value}"
   // prefix + routing.routes.DeparturesRouter.getMessage(departureId.value, "1").url
 
-  def apply(departureId: MovementId, messageId: MessageId, messageResponse: MessageResponse): JsObject =
+  def apply(departureId: DepartureId, messageId: MessageId, messageResponse: MessageResponse): JsObject =
     Json.obj(
       "_links" -> Json.obj(
         "self"      -> Json.obj("href" -> selfUrl(departureId, messageId)),

--- a/app/v2/models/responses/hateoas/HateoasDepartureMessageResponse.scala
+++ b/app/v2/models/responses/hateoas/HateoasDepartureMessageResponse.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.models.responses.hateoas
+
+import play.api.libs.json.JsObject
+import play.api.libs.json.Json
+import v2.models.MessageId
+import v2.models.MovementId
+import v2.models.responses.MessageResponse
+
+object HateoasDepartureMessageResponse {
+
+  lazy val prefix =
+    if (routing.routes.DeparturesRouter.submitDeclaration().url.startsWith("/customs/transits")) ""
+    else "/customs/transits"
+
+  def selfUrl(departureId: MovementId, messageId: MessageId) =
+    prefix + routing.routes.DeparturesRouter.getMessage(departureId.value, messageId.value).url
+
+  // TODO: When we do the departure endpoint, this needs updating
+  def departureUrl(departureId: MovementId) =
+    s"/customs/transits/movements/departures/${departureId.value}"
+  // prefix + routing.routes.DeparturesRouter.getMessage(departureId.value, "1").url
+
+  def apply(departureId: MovementId, messageId: MessageId, messageResponse: MessageResponse): JsObject =
+    Json.obj(
+      "_links" -> Json.obj(
+        "self"      -> Json.obj("href" -> selfUrl(departureId, messageId)),
+        "departure" -> Json.obj("href" -> departureUrl(departureId))
+      ),
+      "departureId" -> departureId.value,
+      "messageId"   -> messageResponse.id,
+      "received"    -> messageResponse.received.toLocalDateTime,
+      "messageType" -> messageResponse.messageType
+    ) ++ messageResponse.body
+      .map(
+        x => Json.obj("body" -> x)
+      )
+      .getOrElse(Json.obj())
+
+}

--- a/app/v2/services/DeparturesService.scala
+++ b/app/v2/services/DeparturesService.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.http.UpstreamErrorResponse
 import v2.connectors.PersistenceConnector
 import v2.models.EORINumber
 import v2.models.MessageId
-import v2.models.MovementId
+import v2.models.DepartureId
 import v2.models.errors.PersistenceError
 import v2.models.responses.DeclarationResponse
 import v2.models.responses.MessageResponse
@@ -45,7 +45,7 @@ trait DeparturesService {
     ec: ExecutionContext
   ): EitherT[Future, PersistenceError, DeclarationResponse]
 
-  def getMessage(eori: EORINumber, departureId: MovementId, messageId: MessageId)(implicit
+  def getMessage(eori: EORINumber, departureId: DepartureId, messageId: MessageId)(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
   ): EitherT[Future, PersistenceError, MessageResponse]
@@ -68,7 +68,7 @@ class DeparturesServiceImpl @Inject() (persistenceConnector: PersistenceConnecto
         }
     )
 
-  override def getMessage(eori: EORINumber, departureId: MovementId, messageId: MessageId)(implicit
+  override def getMessage(eori: EORINumber, departureId: DepartureId, messageId: MessageId)(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
   ): EitherT[Future, PersistenceError, MessageResponse] =

--- a/app/v2/services/DeparturesService.scala
+++ b/app/v2/services/DeparturesService.scala
@@ -22,11 +22,16 @@ import cats.data.EitherT
 import com.google.inject.ImplementedBy
 import com.google.inject.Inject
 import com.google.inject.Singleton
+import play.api.http.Status.NOT_FOUND
 import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.UpstreamErrorResponse
 import v2.connectors.PersistenceConnector
 import v2.models.EORINumber
+import v2.models.MessageId
+import v2.models.MovementId
 import v2.models.errors.PersistenceError
 import v2.models.responses.DeclarationResponse
+import v2.models.responses.MessageResponse
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -39,6 +44,11 @@ trait DeparturesService {
     hc: HeaderCarrier,
     ec: ExecutionContext
   ): EitherT[Future, PersistenceError, DeclarationResponse]
+
+  def getMessage(eori: EORINumber, departureId: MovementId, messageId: MessageId)(implicit
+    hc: HeaderCarrier,
+    ec: ExecutionContext
+  ): EitherT[Future, PersistenceError, MessageResponse]
 
 }
 
@@ -58,4 +68,17 @@ class DeparturesServiceImpl @Inject() (persistenceConnector: PersistenceConnecto
         }
     )
 
+  override def getMessage(eori: EORINumber, departureId: MovementId, messageId: MessageId)(implicit
+    hc: HeaderCarrier,
+    ec: ExecutionContext
+  ): EitherT[Future, PersistenceError, MessageResponse] =
+    EitherT(
+      persistenceConnector
+        .getDepartureMessage(eori, departureId, messageId)
+        .map(Right(_))
+        .recover {
+          case UpstreamErrorResponse(_, NOT_FOUND, _, _) => Left(PersistenceError.MessageNotFound(departureId, messageId))
+          case NonFatal(thr)                             => Left(PersistenceError.UnexpectedError(Some(thr)))
+        }
+    )
 }

--- a/app/v2/services/RouterService.scala
+++ b/app/v2/services/RouterService.scala
@@ -25,7 +25,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import v2.connectors.RouterConnector
 import v2.models.EORINumber
 import v2.models.MessageId
-import v2.models.MovementId
+import v2.models.DepartureId
 import v2.models.errors.RouterError
 import v2.models.request.MessageType
 
@@ -36,7 +36,7 @@ import scala.util.control.NonFatal
 @ImplementedBy(classOf[RouterServiceImpl])
 trait RouterService {
 
-  def send(messageType: MessageType, eoriNumber: EORINumber, movementId: MovementId, messageId: MessageId, body: Source[ByteString, _])(implicit
+  def send(messageType: MessageType, eoriNumber: EORINumber, movementId: DepartureId, messageId: MessageId, body: Source[ByteString, _])(implicit
     ec: ExecutionContext,
     hc: HeaderCarrier
   ): EitherT[Future, RouterError, Unit]
@@ -45,7 +45,7 @@ trait RouterService {
 
 class RouterServiceImpl @Inject() (routerConnector: RouterConnector) extends RouterService {
 
-  def send(messageType: MessageType, eoriNumber: EORINumber, movementId: MovementId, messageId: MessageId, body: Source[ByteString, _])(implicit
+  def send(messageType: MessageType, eoriNumber: EORINumber, movementId: DepartureId, messageId: MessageId, body: Source[ByteString, _])(implicit
     ec: ExecutionContext,
     hc: HeaderCarrier
   ): EitherT[Future, RouterError, Unit] =

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -19,6 +19,6 @@ GET        /movements/departures/:departureId                       controllers.
 POST       /movements/departures/:departureId/messages              controllers.DepartureMessagesController.sendMessageDownstream(departureId: DepartureId)
 GET        /movements/departures/:departureId/messages              controllers.DepartureMessagesController.getDepartureMessages(departureId: DepartureId, receivedSince: Option[OffsetDateTime] ?= None)
 
-GET        /movements/departures/:departureId/messages/:messageId   controllers.DepartureMessagesController.getDepartureMessage(departureId: DepartureId, messageId: MessageId)
+GET        /movements/departures/:departureId/messages/:messageId   routing.DeparturesRouter.getMessage(departureId: String, messageId: String)
 
 GET        /movements/push-pull-notifications/box                   controllers.PushPullNotificationController.getBoxInfo()

--- a/it/connectors/DepartureMessageConnectorSpec.scala
+++ b/it/connectors/DepartureMessageConnectorSpec.scala
@@ -57,7 +57,7 @@ class DepartureMessageConnectorSpec
       val connector = app.injector.instanceOf[DepartureMessageConnector]
 
       val movement = MovementMessage(
-        routes.DepartureMessagesController.getDepartureMessage(DepartureId(1), MessageId(1)).urlWithContext,
+        routing.routes.DeparturesRouter.getMessage(DepartureId(1).toString, MessageId(1).toString).urlWithContext,
         LocalDateTime.now,
         "abc",
         <test>default</test>
@@ -186,13 +186,13 @@ class DepartureMessageConnectorSpec
         LocalDateTime.now,
         Seq(
           MovementMessage(
-            routes.DepartureMessagesController.getDepartureMessage(DepartureId(1), MessageId(1)).urlWithContext,
+            routing.routes.DeparturesRouter.getMessage(DepartureId(1).toString, MessageId(1).toString).urlWithContext,
             LocalDateTime.now,
             "abc",
             <test>default</test>
           ),
           MovementMessage(
-            routes.DepartureMessagesController.getDepartureMessage(DepartureId(1), MessageId(2)).urlWithContext,
+            routing.routes.DeparturesRouter.getMessage(DepartureId(1).toString, MessageId(2).toString).urlWithContext,
             LocalDateTime.now,
             "abc",
             <test>default</test>
@@ -236,13 +236,13 @@ class DepartureMessageConnectorSpec
         LocalDateTime.now,
         Seq(
           MovementMessage(
-            routes.DepartureMessagesController.getDepartureMessage(DepartureId(1), MessageId(1)).urlWithContext,
+            routing.routes.DeparturesRouter.getMessage(DepartureId(1).toString, MessageId(1).toString).urlWithContext,
             LocalDateTime.now,
             "abc",
             <test>default</test>
           ),
           MovementMessage(
-            routes.DepartureMessagesController.getDepartureMessage(DepartureId(1), MessageId(2)).urlWithContext,
+            routing.routes.DeparturesRouter.getMessage(DepartureId(1).toString, MessageId(2).toString).urlWithContext,
             LocalDateTime.now,
             "abc",
             <test>default</test>

--- a/it/v2/connectors/PersistenceConnectorSpec.scala
+++ b/it/v2/connectors/PersistenceConnectorSpec.scala
@@ -51,7 +51,7 @@ import utils.TestMetrics
 import utils.GuiceWiremockSuite
 import v2.models.EORINumber
 import v2.models.MessageId
-import v2.models.MovementId
+import v2.models.DepartureId
 import v2.models.errors.ErrorCode
 import v2.models.errors.PresentationError
 import v2.models.errors.StandardError
@@ -91,7 +91,7 @@ class PersistenceConnectorSpec
 
     lazy val okResultGen =
       for {
-        movementId <- shortUuidGen.arbitrary.map(MovementId.apply)
+        movementId <- shortUuidGen.arbitrary.map(DepartureId.apply)
         messageId  <- shortUuidGen.arbitrary.map(MessageId.apply)
       } yield DeclarationResponse(movementId, messageId)
 
@@ -232,12 +232,12 @@ class PersistenceConnectorSpec
         messageType <- Gen.oneOf(MessageType.values)
       } yield MessageResponse(messageId, now, now, messageType, None, None, Some(s"<test>$body</test>"))
 
-    def targetUrl(eoriNumber: EORINumber, departureId: MovementId, messageId: MessageId) =
+    def targetUrl(eoriNumber: EORINumber, departureId: DepartureId, messageId: MessageId) =
       s"/transit-movements/traders/${eoriNumber.value}/movements/departures/${departureId.value}/messages/${messageId.value}/"
 
     "on successful message, return a success" in {
       val eori            = eoriNumberGen.sample.get
-      val departureId     = shortUuidGen.arbitrary.map(MovementId.apply).sample.get
+      val departureId     = shortUuidGen.arbitrary.map(DepartureId.apply).sample.get
       val messageResponse = okResultGen.sample.get
 
       server.stubFor(
@@ -263,7 +263,7 @@ class PersistenceConnectorSpec
     "on incorrect Json, return an error" in {
 
       val eori        = eoriNumberGen.sample.get
-      val departureId = shortUuidGen.arbitrary.map(MovementId.apply).sample.get
+      val departureId = shortUuidGen.arbitrary.map(DepartureId.apply).sample.get
       val messageId   = shortUuidGen.arbitrary.map(MessageId.apply).sample.get
       server.stubFor(
         get(
@@ -298,7 +298,7 @@ class PersistenceConnectorSpec
 
     "on not found, return an UpstreamServerError" in forAll(
       eoriNumberGen,
-      shortUuidGen.arbitrary.map(MovementId.apply),
+      shortUuidGen.arbitrary.map(DepartureId.apply),
       shortUuidGen.arbitrary.map(MessageId.apply)
     ) {
       (eori, departureId, messageId) =>
@@ -338,7 +338,7 @@ class PersistenceConnectorSpec
 
     "on an internal error, return an UpstreamServerError" in {
       val eori        = eoriNumberGen.sample.get
-      val departureId = shortUuidGen.arbitrary.map(MovementId.apply).sample.get
+      val departureId = shortUuidGen.arbitrary.map(DepartureId.apply).sample.get
       val messageId   = shortUuidGen.arbitrary.map(MessageId.apply).sample.get
 
       server.stubFor(

--- a/it/v2/connectors/RouterConnectorSpec.scala
+++ b/it/v2/connectors/RouterConnectorSpec.scala
@@ -46,7 +46,7 @@ import utils.TestMetrics
 import utils.GuiceWiremockSuite
 import v2.models.EORINumber
 import v2.models.MessageId
-import v2.models.MovementId
+import v2.models.DepartureId
 import v2.models.errors.ErrorCode
 import v2.models.errors.PresentationError
 import v2.models.errors.StandardError
@@ -80,12 +80,12 @@ class RouterConnectorSpec
     })
 
     lazy val messageTypeGen = Gen.oneOf(Seq(MessageType.DepartureDeclaration))
-    lazy val movementIdGen  = shortUuidGen.arbitrary.map(MovementId.apply)
+    lazy val movementIdGen  = shortUuidGen.arbitrary.map(DepartureId.apply)
     lazy val messageIdGen   = shortUuidGen.arbitrary.map(MessageId.apply)
 
     lazy val eoriNumberGen = Gen.alphaNumStr.map(EORINumber.apply)
 
-    def targetUrl(eoriNumber: EORINumber, messageType: MessageType, movementId: MovementId, messageId: MessageId) =
+    def targetUrl(eoriNumber: EORINumber, messageType: MessageType, movementId: DepartureId, messageId: MessageId) =
       s"/transit-movements-router/traders/${eoriNumber.value}/movements/${messageType.movementType}/${movementId.value}/messages/${messageId.value}/"
 
     "When ACCEPTED is received, must returned a successful future" in forAll(eoriNumberGen, messageTypeGen, movementIdGen, messageIdGen) {

--- a/it/v2/utils/CommonGenerators.scala
+++ b/it/v2/utils/CommonGenerators.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.utils
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
+import v2.models.DepartureId
+import v2.models.EORINumber
+import v2.models.MessageId
+
+trait CommonGenerators {
+
+  lazy val genShortUUID: Gen[String] = Gen.long.map {
+    l: Long =>
+      f"${BigInt(l)}%016x"
+  }
+
+  implicit lazy val arbitraryDepartureId: Arbitrary[DepartureId] = Arbitrary {
+    genShortUUID.map(DepartureId(_))
+  }
+
+  implicit lazy val arbitraryMessageId: Arbitrary[MessageId] = Arbitrary {
+    genShortUUID.map(MessageId(_))
+  }
+
+  implicit lazy val arbitraryEORINumber: Arbitrary[EORINumber] = Arbitrary {
+    Gen.alphaNumStr.map(EORINumber(_))
+  }
+
+}

--- a/resources/public/api/conf/2.0/application.raml
+++ b/resources/public/api/conf/2.0/application.raml
@@ -150,4 +150,11 @@ traits:
                         "body": "<CC015C>...</CC015C>"
                       }
               404:
-                description: When message does not exist, has been archived or is not available to the EORI number.
+                body:
+                  application/json:
+                    type: types.errorResponse
+                    examples:
+                      schemaValidation:
+                        description: The requested message does not exist, has been archived, or is not available to the EORI number
+                        value:
+                          code: NOT_FOUND

--- a/resources/public/api/conf/2.0/application.raml
+++ b/resources/public/api/conf/2.0/application.raml
@@ -113,3 +113,41 @@ traits:
                     }
                   }
                 }
+
+    /{departureId}:
+      /messages:
+        /{messageId}:
+          get:
+            displayName: Get a message relating to a Movement Departure and message ID
+            description: |
+              Get all messages relating to a specific Movement Departure and message ID. For example, this could include declaration rejected or Movement Reference Number (MRN) allocated messages. Any messages more than 31 days old will be archived. Archived notifications will be return an HTTP 404 Not Found status.
+
+              You will only be able to retrieve these messages if you have the EORI number associated with the Movement Departure.
+            is:
+              - acceptJsonHeader
+              - acceptHeaderInvalid
+            (annotations.scope): "common-transit-convention-traders"
+            securedBy: [ sec.oauth_2_0: { scopes: [ "common-transit-convention-traders" ] } ]
+            responses:
+              200:
+                body:
+                  application/json:
+                    description: JSON Payload
+                    example: |
+                      {
+                        "_links": {
+                          "self": {
+                            "href": "/customs/transits/movements/departures/0123456789abcdef/messages/abcdef0123456789"
+                          },
+                          "departure": {
+                            "href": "/customs/transits/movements/departures/0123456789abcdef"
+                          }
+                        },
+                        "departureId": "0123456789abcdef",
+                        "messageId": "abcdef0123456789",
+                        "received": "2020-10-10T10:10:10",
+                        "messageType": "IE015",
+                        "body": "<CC015C>...</CC015C>"
+                      }
+              404:
+                description: When message does not exist, has been archived or is not available to the EORI number.

--- a/test/controllers/DepartureMessagesControllerSpec.scala
+++ b/test/controllers/DepartureMessagesControllerSpec.scala
@@ -84,7 +84,7 @@ class DepartureMessagesControllerSpec
   }
 
   val sourceMovement = MovementMessage(
-    routes.DepartureMessagesController.getDepartureMessage(DepartureId(123), MessageId(4)).urlWithContext,
+    routing.routes.DeparturesRouter.getMessage(DepartureId(123).toString, MessageId(4).toString).urlWithContext,
     LocalDateTime.of(2020, 2, 2, 2, 2, 2),
     "IE025",
     <test>default</test>
@@ -272,7 +272,7 @@ class DepartureMessagesControllerSpec
 
       val request = FakeRequest(
         "GET",
-        routes.DepartureMessagesController.getDepartureMessage(DepartureId(123), MessageId(4)).url,
+        routing.routes.DeparturesRouter.getMessage(DepartureId(123).toString, MessageId(4).toString).url,
         headers = FakeHeaders(Seq(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")),
         AnyContentAsEmpty
       )
@@ -288,7 +288,7 @@ class DepartureMessagesControllerSpec
 
       val request = FakeRequest(
         "GET",
-        routes.DepartureMessagesController.getDepartureMessage(DepartureId(123), MessageId(4)).url,
+        routing.routes.DeparturesRouter.getMessage(DepartureId(123).toString, MessageId(4).toString).url,
         headers = FakeHeaders(Seq(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")),
         AnyContentAsEmpty
       )
@@ -306,7 +306,7 @@ class DepartureMessagesControllerSpec
 
       val request = FakeRequest(
         "GET",
-        routes.DepartureMessagesController.getDepartureMessage(DepartureId(123), MessageId(4)).url,
+        routing.routes.DeparturesRouter.getMessage(DepartureId(123).toString, MessageId(4).toString).url,
         headers = FakeHeaders(Seq(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")),
         AnyContentAsEmpty
       )
@@ -328,7 +328,7 @@ class DepartureMessagesControllerSpec
 
       val request = FakeRequest(
         "GET",
-        routes.DepartureMessagesController.getDepartureMessage(DepartureId(123), MessageId(4)).url,
+        routing.routes.DeparturesRouter.getMessage(DepartureId(123).toString, MessageId(4).toString).url,
         headers = FakeHeaders(Seq(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")),
         AnyContentAsEmpty
       )
@@ -343,7 +343,7 @@ class DepartureMessagesControllerSpec
 
       val request = FakeRequest(
         "GET",
-        routes.DepartureMessagesController.getDepartureMessage(DepartureId(123), MessageId(4)).url,
+        routing.routes.DeparturesRouter.getMessage(DepartureId(123).toString, MessageId(4).toString).url,
         headers = FakeHeaders(Seq(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")),
         AnyContentAsEmpty
       )
@@ -388,7 +388,7 @@ class DepartureMessagesControllerSpec
 
       status(result) mustBe ACCEPTED
       contentAsString(result) mustEqual expectedJson.toString()
-      headers(result) must contain(LOCATION -> routes.DepartureMessagesController.getDepartureMessage(DepartureId(123), MessageId(1)).urlWithContext)
+      headers(result) must contain(LOCATION -> routing.routes.DeparturesRouter.getMessage(DepartureId(123).toString, MessageId(1).toString).urlWithContext)
     }
 
     "must return InternalServerError when unsuccessful" in {
@@ -438,7 +438,7 @@ class DepartureMessagesControllerSpec
 
       status(result) mustBe ACCEPTED
       contentAsString(result) mustEqual expectedJson.toString()
-      headers(result) must contain(LOCATION -> routes.DepartureMessagesController.getDepartureMessage(DepartureId(123), MessageId(1)).urlWithContext)
+      headers(result) must contain(LOCATION -> routing.routes.DeparturesRouter.getMessage(DepartureId(123).toString, MessageId(1).toString).urlWithContext)
     }
 
     "must return UnsupportedMediaType when Content-Type is JSON" in {

--- a/test/routing/DeparturesRouterSpec.scala
+++ b/test/routing/DeparturesRouterSpec.scala
@@ -16,78 +16,196 @@
 
 package routing
 
+import akka.util.ByteString
 import akka.util.Timeout
-import controllers.V1DeparturesController
 import org.scalatest.OptionValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.http.HeaderNames
 import play.api.http.Status.ACCEPTED
-import play.api.inject.bind
-import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.http.Status.BAD_REQUEST
 import play.api.libs.json.Json
 import play.api.test.FakeHeaders
 import play.api.test.FakeRequest
+import play.api.test.Helpers.call
 import play.api.test.Helpers.contentAsJson
-import play.api.test.Helpers.route
 import play.api.test.Helpers.status
-import v2.controllers.V2DeparturesController
+import play.api.test.Helpers.stubControllerComponents
+import v2.base.TestActorSystem
+import v2.fakes.controllers.FakeV1DepartureMessagesController
 import v2.fakes.controllers.FakeV1DeparturesController
 import v2.fakes.controllers.FakeV2DeparturesController
 
 import scala.concurrent.duration.DurationInt
 
-class DeparturesRouterSpec extends AnyFreeSpec with Matchers with OptionValues with ScalaFutures with MockitoSugar with GuiceOneAppPerSuite {
+class DeparturesRouterSpec extends AnyFreeSpec with Matchers with OptionValues with ScalaFutures with MockitoSugar with TestActorSystem {
 
   implicit private val timeout: Timeout = 5.seconds
 
-  override lazy val app = GuiceApplicationBuilder()
-    .overrides(
-      bind[V1DeparturesController].to[FakeV1DeparturesController],
-      bind[V2DeparturesController].to[FakeV2DeparturesController]
-    )
-    .build()
+  val sut = new DeparturesRouter(
+    stubControllerComponents(),
+    new FakeV1DeparturesController,
+    new FakeV1DepartureMessagesController,
+    new FakeV2DeparturesController
+  )
 
-  // Version 2
-  "with accept header set to application/vnd.hmrc.2.0+json (version two)" - {
+  "when submitting a departure" - {
+    // Version 2
+    "with accept header set to application/vnd.hmrc.2.0+json (version two)" - {
 
-    val departureHeaders = FakeHeaders(Seq(HeaderNames.ACCEPT -> "application/vnd.hmrc.2.0+json", HeaderNames.CONTENT_TYPE -> "application/xml"))
+      val departureHeaders = FakeHeaders(
+        Seq(HeaderNames.ACCEPT -> "application/vnd.hmrc.2.0+json", HeaderNames.CONTENT_TYPE -> "application/xml")
+      )
 
-    "must route to the v2 controller and return Accepted when successful" in {
+      "must route to the v2 controller and return Accepted when successful" in {
 
-      val request = FakeRequest(method = "POST", uri = routes.DeparturesRouter.submitDeclaration().url, body = <test></test>, headers = departureHeaders)
-      val result  = route(app, request).value
+        val request = FakeRequest(method = "POST", uri = routes.DeparturesRouter.submitDeclaration().url, body = <test></test>, headers = departureHeaders)
+        val result  = call(sut.submitDeclaration(), request)
 
-      status(result) mustBe ACCEPTED
-      contentAsJson(result) mustBe Json.obj("version" -> 2) // ensure we get the unique value to verify we called the fake action
+        status(result) mustBe ACCEPTED
+        contentAsJson(result) mustBe Json.obj("version" -> 2) // ensure we get the unique value to verify we called the fake action
+      }
+
     }
 
+    Seq(None, Some("application/vnd.hmrc.1.0+json"), Some("text/html"), Some("application/vnd.hmrc.1.0+xml"), Some("text/javascript")).foreach {
+      acceptHeaderValue =>
+        val acceptHeader = acceptHeaderValue
+          .map(
+            header => Seq(HeaderNames.ACCEPT -> header)
+          )
+          .getOrElse(Seq.empty)
+        val departureHeaders = FakeHeaders(acceptHeader ++ Seq(HeaderNames.CONTENT_TYPE -> "application/xml"))
+        val withString = acceptHeaderValue
+          .getOrElse("nothing")
+        s"with accept header set to $withString" - {
+
+          "must route to the v1 controller and return Accepted when successful" in {
+
+            val request = FakeRequest(method = "POST", uri = routes.DeparturesRouter.submitDeclaration().url, body = <test></test>, headers = departureHeaders)
+            val result  = call(sut.submitDeclaration(), request)
+
+            status(result) mustBe ACCEPTED
+            contentAsJson(result) mustBe Json.obj("version" -> 1) // ensure we get the unique value to verify we called the fake action
+          }
+        }
+
+    }
   }
 
-  Seq(None, Some("application/vnd.hmrc.1.0+json"), Some("text/html"), Some("application/vnd.hmrc.1.0+xml"), Some("text/javascript")).foreach {
-    acceptHeaderValue =>
-      val acceptHeader = acceptHeaderValue
-        .map(
-          header => Seq(HeaderNames.ACCEPT -> header)
-        )
-        .getOrElse(Seq.empty)
-      val departureHeaders = FakeHeaders(acceptHeader ++ Seq(HeaderNames.CONTENT_TYPE -> "application/xml"))
-      val withString = acceptHeaderValue
-        .getOrElse("nothing")
-      s"with accept header set to $withString" - {
+  "when getting a single message" - {
 
-        "must route to the v1 controller and return Accepted when successful" in {
+    "with accept header set to application/vnd.hmrc.2.0+json (version two)" - {
 
-          val request = FakeRequest(method = "POST", uri = routes.DeparturesRouter.submitDeclaration().url, body = <test></test>, headers = departureHeaders)
-          val result  = route(app, request).value
+      val departureHeaders = FakeHeaders(Seq(HeaderNames.ACCEPT -> "application/vnd.hmrc.2.0+json", HeaderNames.CONTENT_TYPE -> "application/xml"))
 
-          status(result) mustBe ACCEPTED
-          contentAsJson(result) mustBe Json.obj("version" -> 1) // ensure we get the unique value to verify we called the fake action
-        }
+      "must route to the v2 controller and return Accepted when successful" in {
+
+        val request = FakeRequest(method = "POST", uri = routes.DeparturesRouter.submitDeclaration().url, body = <test></test>, headers = departureHeaders)
+        val result  = sut.getMessage("1234567890abcdef", "1234567890abcdef")(request)
+
+        status(result) mustBe ACCEPTED
+        contentAsJson(result) mustBe Json.obj("version" -> 2) // ensure we get the unique value to verify we called the fake action
       }
+
+      "if the departure ID is not the correct format, return a bad request of the appropriate format" in {
+        val request = FakeRequest(
+          method = "POST",
+          uri = routes.DeparturesRouter.getMessage("01", "0123456789abcdef").url,
+          body = <test></test>,
+          headers = FakeHeaders(Seq(HeaderNames.ACCEPT -> "application/vnd.hmrc.2.0+json", HeaderNames.CONTENT_TYPE -> "application/xml"))
+        )
+        val result = sut.getMessage("01", "01234567890bcdef")(request)
+
+        status(result) mustBe BAD_REQUEST
+        contentAsJson(result) mustBe Json.obj(
+          "code"       -> "BAD_REQUEST",
+          "statusCode" -> 400,
+          "message"    -> "departureId: Value 01 is not a 16 character hexadecimal string"
+        )
+      }
+
+      "if the message ID is not the correct format, return a bad request of the appropriate format" in {
+        val request = FakeRequest(
+          method = "POST",
+          uri = routes.DeparturesRouter.getMessage("0123456789abcdef", "01").url,
+          body = <test></test>,
+          headers = FakeHeaders(Seq(HeaderNames.ACCEPT -> "application/vnd.hmrc.2.0+json", HeaderNames.CONTENT_TYPE -> "application/xml"))
+        )
+        val result = sut.getMessage("01234567890bcdef", "01")(request)
+
+        status(result) mustBe BAD_REQUEST
+        contentAsJson(result) mustBe Json.obj(
+          "code"       -> "BAD_REQUEST",
+          "statusCode" -> 400,
+          "message"    -> "messageId: Value 01 is not a 16 character hexadecimal string"
+        )
+      }
+
+    }
+
+    Seq(None, Some("application/vnd.hmrc.1.0+json"), Some("text/html"), Some("application/vnd.hmrc.1.0+xml"), Some("text/javascript")).foreach {
+      acceptHeaderValue =>
+        val acceptHeader = acceptHeaderValue
+          .map(
+            header => Seq(HeaderNames.ACCEPT -> header)
+          )
+          .getOrElse(Seq.empty)
+        val departureHeaders = FakeHeaders(acceptHeader ++ Seq(HeaderNames.CONTENT_TYPE -> "application/xml"))
+        val withString = acceptHeaderValue
+          .getOrElse("nothing")
+        s"with accept header set to $withString" - {
+
+          "must route to the v1 controller and return Accepted when successful" in {
+
+            val request =
+              FakeRequest(method = "POST", uri = routes.DeparturesRouter.getMessage("123", "4").url, body = <test></test>, headers = departureHeaders)
+            val result = sut.getMessage("123", "4")(request)
+
+            status(result) mustBe ACCEPTED
+            contentAsJson(result) mustBe Json.obj("version" -> 1) // ensure we get the unique value to verify we called the fake action
+          }
+        }
+
+    }
+
+    "with accept header set to \"application/vnd.hmrc.1.0+json\" and incorrect IDs" - {
+      "if the departure ID is not the correct format, return a bad request of the appropriate format" in {
+        val request = FakeRequest(
+          method = "POST",
+          uri = routes.DeparturesRouter.getMessage("a", "1").url,
+          body = <test></test>,
+          headers = FakeHeaders(Seq(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json", HeaderNames.CONTENT_TYPE -> "application/xml"))
+        )
+        val result = sut.getMessage("a", "1")(request)
+
+        status(result) mustBe BAD_REQUEST
+        contentAsJson(result) mustBe Json.obj(
+          "code"       -> "BAD_REQUEST",
+          "statusCode" -> 400,
+          "message"    -> "Cannot parse parameter departureId as Int: For input string: \"a\""
+        )
+      }
+
+      "if the message ID is not the correct format, return a bad request of the appropriate format" in {
+        val request = FakeRequest(
+          method = "POST",
+          uri = routes.DeparturesRouter.getMessage("1", "a").url,
+          body = <test></test>,
+          headers = FakeHeaders(Seq(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json", HeaderNames.CONTENT_TYPE -> "application/xml"))
+        )
+        val result = sut.getMessage("1", "a")(request)
+
+        status(result) mustBe BAD_REQUEST
+        contentAsJson(result) mustBe Json.obj(
+          "code"       -> "BAD_REQUEST",
+          "statusCode" -> 400,
+          "message"    -> "Cannot parse parameter messageId as Int: For input string: \"a\""
+        )
+      }
+    }
 
   }
 }

--- a/test/v2/base/CommonGenerators.scala
+++ b/test/v2/base/CommonGenerators.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.base
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
+import v2.models.AuditType
+import v2.models.DepartureId
+import v2.models.EORINumber
+import v2.models.MessageId
+import v2.models.request.MessageType
+
+trait CommonGenerators {
+
+  lazy val genShortUUID: Gen[String] = Gen.long.map {
+    l: Long =>
+      f"${BigInt(l)}%016x"
+  }
+
+  implicit lazy val arbitraryDepartureId: Arbitrary[DepartureId] = Arbitrary {
+    genShortUUID.map(DepartureId(_))
+  }
+
+  implicit lazy val arbitraryMessageId: Arbitrary[MessageId] = Arbitrary {
+    genShortUUID.map(MessageId(_))
+  }
+
+  implicit lazy val arbitraryEORINumber: Arbitrary[EORINumber] = Arbitrary {
+    Gen.alphaNumStr.map(EORINumber(_))
+  }
+
+  implicit lazy val arbitraryMessageType: Arbitrary[MessageType] = Arbitrary {
+    Gen.oneOf(MessageType.values)
+  }
+
+  implicit lazy val arbitraryAuditType: Arbitrary[AuditType] = Arbitrary {
+    Gen.oneOf(AuditType.values)
+  }
+
+}

--- a/test/v2/connectors/V2BaseConnectorSpec.scala
+++ b/test/v2/connectors/V2BaseConnectorSpec.scala
@@ -23,6 +23,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
+import org.scalatest.OptionValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
@@ -57,6 +58,7 @@ class V2BaseConnectorSpec
     with CommonGenerators
     with ScalaCheckDrivenPropertyChecks
     with ScalaFutures
+    with OptionValues
     with TestActorSystem {
 
   object Harness extends V2BaseConnector
@@ -68,16 +70,16 @@ class V2BaseConnectorSpec
   }
 
   "the post departure movements URL on localhost for a given EORI should be as expected" in {
-    val eori    = arbitrary[EORINumber].sample.get
+    val eori    = arbitrary[EORINumber].sample.value
     val urlPath = Harness.movementsPostDepartureDeclaration(eori)
 
     urlPath.toString() mustBe s"/transit-movements/traders/${eori.value}/movements/departures/"
   }
 
   "the get single departure movement URL on localhost for a given EORI, departure ID or message ID should be as expected" in {
-    val eori        = arbitrary[EORINumber].sample.get
-    val departureId = arbitrary[DepartureId].sample.get
-    val messageId   = arbitrary[MessageId].sample.get
+    val eori        = arbitrary[EORINumber].sample.value
+    val departureId = arbitrary[DepartureId].sample.value
+    val messageId   = arbitrary[MessageId].sample.value
     val urlPath     = Harness.movementsGetDepartureMessage(eori, departureId, messageId)
 
     urlPath.toString() mustBe s"/transit-movements/traders/${eori.value}/movements/departures/${departureId.value}/messages/${messageId.value}/"
@@ -85,9 +87,9 @@ class V2BaseConnectorSpec
 
   "the router message submission URL on localhost for a given EORI, departure ID or message ID should be as expected" in forAll(arbitrary[MessageType]) {
     messageType =>
-      val eori        = arbitrary[EORINumber].sample.get
-      val departureId = arbitrary[DepartureId].sample.get
-      val messageId   = arbitrary[MessageId].sample.get
+      val eori        = arbitrary[EORINumber].sample.value
+      val departureId = arbitrary[DepartureId].sample.value
+      val messageId   = arbitrary[MessageId].sample.value
       val urlPath     = Harness.routerRoute(eori, messageType, departureId, messageId)
       urlPath
         .toString() mustBe s"/transit-movements-router/traders/${eori.value}/movements/${messageType.movementType}/${departureId.value}/messages/${messageId.value}/"
@@ -152,8 +154,8 @@ class V2BaseConnectorSpec
     }
 
     "errorFromStream creates the appropriate failed Future" in {
-      val string1  = Gen.alphaNumStr.sample.get
-      val string2  = Gen.alphaNumStr.sample.get
+      val string1  = Gen.alphaNumStr.sample.value
+      val string2  = Gen.alphaNumStr.sample.value
       val expected = string1 + string2
 
       val sut = mock[HttpResponse]
@@ -183,7 +185,7 @@ class V2BaseConnectorSpec
     }
 
     "error returns a simple upstream error response" in {
-      val expected = Gen.alphaNumStr.sample.get
+      val expected = Gen.alphaNumStr.sample.value
       val sut      = mock[HttpResponse]
       when(sut.body).thenReturn(expected)
       when(sut.status).thenReturn(INTERNAL_SERVER_ERROR)

--- a/test/v2/connectors/V2BaseConnectorSpec.scala
+++ b/test/v2/connectors/V2BaseConnectorSpec.scala
@@ -16,23 +16,267 @@
 
 package v2.connectors
 
-import io.lemonlabs.uri.UrlPath
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import org.bouncycastle.util.test.TestFailedException
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import play.api.http.Status.ACCEPTED
+import play.api.http.Status.INTERNAL_SERVER_ERROR
+import play.api.http.Status.OK
+import play.api.libs.json.JsResult
+import play.api.libs.json.Json
+import play.api.libs.json.Reads
+import play.api.test.Helpers.await
+import play.api.test.Helpers.defaultAwaitTimeout
+import uk.gov.hmrc.http.HttpResponse
+import uk.gov.hmrc.http.UpstreamErrorResponse
+import uk.gov.hmrc.http.client.RequestBuilder
+import v2.base.CommonGenerators
+import v2.base.TestActorSystem
+import v2.models.AuditType
+import v2.models.DepartureId
+import v2.models.EORINumber
+import v2.models.MessageId
 import v2.models.request.MessageType
 
-class V2BaseConnectorSpec extends AnyFreeSpec with Matchers with MockitoSugar {
+import scala.concurrent.ExecutionContext.Implicits._
+import scala.concurrent.Future
 
-  object Harness extends V2BaseConnector {
+class V2BaseConnectorSpec
+    extends AnyFreeSpec
+    with Matchers
+    with MockitoSugar
+    with CommonGenerators
+    with ScalaCheckDrivenPropertyChecks
+    with ScalaFutures
+    with TestActorSystem {
 
-    def validationRouteTest(messageType: MessageType): UrlPath = validationRoute(messageType)
-  }
+  object Harness extends V2BaseConnector
 
   "the validation URL for an IE015 message type on localhost should be as expected" in {
-    val urlPath = Harness.validationRouteTest(MessageType.DepartureDeclaration)
+    val urlPath = Harness.validationRoute(MessageType.DepartureDeclaration)
 
     urlPath.toString() mustBe "/transit-movements-validator/messages/IE015/validation"
+  }
+
+  "the post departure movements URL on localhost for a given EORI should be as expected" in {
+    val eori    = arbitrary[EORINumber].sample.get
+    val urlPath = Harness.movementsPostDepartureDeclaration(eori)
+
+    urlPath.toString() mustBe s"/transit-movements/traders/${eori.value}/movements/departures/"
+  }
+
+  "the get single departure movement URL on localhost for a given EORI, departure ID or message ID should be as expected" in {
+    val eori        = arbitrary[EORINumber].sample.get
+    val departureId = arbitrary[DepartureId].sample.get
+    val messageId   = arbitrary[MessageId].sample.get
+    val urlPath     = Harness.movementsGetDepartureMessage(eori, departureId, messageId)
+
+    urlPath.toString() mustBe s"/transit-movements/traders/${eori.value}/movements/departures/${departureId.value}/messages/${messageId.value}/"
+  }
+
+  "the router message submission URL on localhost for a given EORI, departure ID or message ID should be as expected" in forAll(arbitrary[MessageType]) {
+    messageType =>
+      val eori        = arbitrary[EORINumber].sample.get
+      val departureId = arbitrary[DepartureId].sample.get
+      val messageId   = arbitrary[MessageId].sample.get
+      val urlPath     = Harness.routerRoute(eori, messageType, departureId, messageId)
+      urlPath
+        .toString() mustBe s"/transit-movements-router/traders/${eori.value}/movements/${messageType.movementType}/${departureId.value}/messages/${messageId.value}/"
+  }
+
+  "the auditing URL on localhost for a given audit type should be as expected" in forAll(arbitrary[AuditType]) {
+    auditType =>
+      val urlPath = Harness.auditingRoute(auditType)
+
+      urlPath.toString() mustBe s"/transit-movements-auditing/audit/${auditType.name}"
+  }
+
+  "the conversion URL on localhost for a given message type should be as expected" in forAll(arbitrary[MessageType]) {
+    messageType =>
+      val urlPath = Harness.conversionRoute(messageType)
+
+      urlPath.toString() mustBe s"/transit-movements-converter/messages/${messageType.code}"
+  }
+
+  "HttpResponseHelpers" - new V2BaseConnector() {
+
+    case class TestObject(string: String, int: Int)
+
+    implicit val reads: Reads[TestObject] = Json.reads[TestObject]
+
+    "successfully converting a relevant object using 'as' returns the object" in {
+      val sut = mock[HttpResponse]
+      when(sut.json).thenReturn(
+        Json.obj(
+          "string" -> "string",
+          "int"    -> 1
+        )
+      )
+
+      whenReady(sut.as[TestObject]) {
+        _ mustBe TestObject("string", 1)
+      }
+    }
+
+    "unsuccessfully converting an object using 'as' returns a failed future" in {
+      val sut = mock[HttpResponse]
+      when(sut.json).thenReturn(
+        Json.obj(
+          "no"  -> "string",
+          "no2" -> 1
+        )
+      )
+
+      val result = sut
+        .as[TestObject]
+        .map(
+          _ => fail("This should have failed")
+        )
+        .recover {
+          case _: JsResult.Exception  => // success
+          case x: TestFailedException => x
+          case thr                    => fail(s"Test failed in an unexpected way: $thr")
+        }
+
+      // we just want the future to complete
+      await(result)
+    }
+
+    "errorFromStream creates the appropriate failed Future" in {
+      val string1  = Gen.alphaNumStr.sample.get
+      val string2  = Gen.alphaNumStr.sample.get
+      val expected = string1 + string2
+
+      val sut = mock[HttpResponse]
+      when(sut.bodyAsSource).thenAnswer(
+        _ =>
+          Source.fromIterator(
+            () => Seq(ByteString(string1), ByteString(string2)).iterator
+          )
+      )
+
+      when(sut.status).thenReturn(INTERNAL_SERVER_ERROR)
+
+      val result = sut
+        .errorFromStream[HttpResponse]
+        .map(
+          _ => fail("This should have failed")
+        )
+        .recover {
+          case UpstreamErrorResponse(`expected`, INTERNAL_SERVER_ERROR, _, _) => // success
+          case x: TestFailedException                                         => x
+          case thr =>
+            fail(s"Test failed in an unexpected way: $thr")
+        }
+
+      // we just want the future to complete
+      await(result)
+    }
+
+    "error returns a simple upstream error response" in {
+      val expected = Gen.alphaNumStr.sample.get
+      val sut      = mock[HttpResponse]
+      when(sut.body).thenReturn(expected)
+      when(sut.status).thenReturn(INTERNAL_SERVER_ERROR)
+
+      val result = sut
+        .error[TestObject]
+        .map(
+          _ => fail("This should have failed")
+        )
+        .recover {
+          case UpstreamErrorResponse(`expected`, INTERNAL_SERVER_ERROR, _, _) => // success
+          case x: TestFailedException                                         => x
+          case thr =>
+            fail(s"Test failed in an unexpected way: $thr")
+        }
+
+      await(result)
+    }
+
+  }
+
+  "RequestBuilderHelpers" - new V2BaseConnector {
+
+    "executeAccepted returns a unit when accepted" in {
+      val response = mock[HttpResponse]
+      when(response.status).thenReturn(ACCEPTED)
+      val sut = mock[RequestBuilder]
+      when(sut.execute[HttpResponse](any(), any())).thenReturn(Future.successful(response))
+
+      whenReady(sut.executeAccepted) {
+        unit => unit mustBe a[Unit]
+      }
+
+    }
+
+    "executeAccepted returns an error when not accepted" in {
+      val response = mock[HttpResponse]
+      when(response.status).thenReturn(INTERNAL_SERVER_ERROR)
+      when(response.body).thenReturn("error")
+      val sut = mock[RequestBuilder]
+      when(sut.execute[HttpResponse](any(), any())).thenReturn(Future.successful(response))
+
+      sut.executeAccepted
+        .map(
+          _ => fail("This should have failed")
+        )
+        .recover {
+          case UpstreamErrorResponse("error", INTERNAL_SERVER_ERROR, _, _) => // success
+          case x: TestFailedException                                      => x
+          case thr =>
+            fail(s"Test failed in an unexpected way: $thr")
+        }
+
+    }
+
+    "executeAsStream returns the body as a source when OK" in {
+      val response = mock[HttpResponse]
+      val source   = Source.empty[ByteString]
+      when(response.status).thenReturn(OK)
+      when(response.bodyAsSource).thenAnswer(
+        _ => source
+      )
+      val sut = mock[RequestBuilder]
+      when(sut.stream[HttpResponse](any(), any())).thenReturn(Future.successful(response))
+
+      whenReady(sut.executeAsStream) {
+        _ mustBe source
+      }
+
+    }
+
+    "executeAsStream returns an error for an appropriate status code" in {
+      val response = mock[HttpResponse]
+      when(response.status).thenReturn(INTERNAL_SERVER_ERROR)
+      when(response.bodyAsSource).thenAnswer(
+        _ => Source.single(ByteString("error"))
+      )
+      val sut = mock[RequestBuilder]
+      when(sut.stream[HttpResponse](any(), any())).thenReturn(Future.successful(response))
+
+      sut.executeAsStream
+        .map(
+          _ => fail("This should have failed")
+        )
+        .recover {
+          case UpstreamErrorResponse("error", INTERNAL_SERVER_ERROR, _, _) => // success
+          case x: TestFailedException                                      => x
+          case thr =>
+            fail(s"Test failed in an unexpected way: $thr")
+        }
+
+    }
+
   }
 
 }

--- a/test/v2/controllers/ErrorTranslatorSpec.scala
+++ b/test/v2/controllers/ErrorTranslatorSpec.scala
@@ -26,7 +26,7 @@ import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import v2.models.MessageId
-import v2.models.MovementId
+import v2.models.DepartureId
 import v2.models.errors.FailedToValidateError
 import v2.models.errors.JsonValidationError
 import v2.models.errors.PersistenceError
@@ -109,7 +109,7 @@ class ErrorTranslatorSpec extends AnyFreeSpec with Matchers with OptionValues wi
   "Persistence Error" - {
     "a MessageNotFound error returns a NOT_FOUND" in {
       val hexId      = Gen.listOfN(16, Gen.hexChar).map(_.mkString.toLowerCase)
-      val movementId = MovementId(hexId.sample.getOrElse("1234567890abcedf"))
+      val movementId = DepartureId(hexId.sample.getOrElse("1234567890abcedf"))
       val messageId  = MessageId(hexId.sample.getOrElse("1234567890abcedf"))
 
       val input  = PersistenceError.MessageNotFound(movementId, messageId)

--- a/test/v2/controllers/V2DeparturesControllerSpec.scala
+++ b/test/v2/controllers/V2DeparturesControllerSpec.scala
@@ -696,7 +696,7 @@ class V2DeparturesControllerSpec
           .thenAnswer(
             _ =>
               EitherT.rightT(
-                DeclarationResponse(MovementId("123"), MessageId("456"))
+                DeclarationResponse(DepartureId("123"), MessageId("456"))
               )
           )
 
@@ -704,7 +704,7 @@ class V2DeparturesControllerSpec
           mockRouterService.send(
             eqTo(MessageType.DepartureDeclaration),
             any[String].asInstanceOf[EORINumber],
-            any[String].asInstanceOf[MovementId],
+            any[String].asInstanceOf[DepartureId],
             any[String].asInstanceOf[MessageId],
             any[Source[ByteString, _]]
           )(any[ExecutionContext], any[HeaderCarrier])
@@ -724,7 +724,7 @@ class V2DeparturesControllerSpec
         verify(mockRouterService).send(
           eqTo(MessageType.DepartureDeclaration),
           any[String].asInstanceOf[EORINumber],
-          any[String].asInstanceOf[MovementId],
+          any[String].asInstanceOf[DepartureId],
           any[String].asInstanceOf[MessageId],
           any[Source[ByteString, _]]
         )(any[ExecutionContext], any[HeaderCarrier])

--- a/test/v2/controllers/V2DeparturesControllerSpec.scala
+++ b/test/v2/controllers/V2DeparturesControllerSpec.scala
@@ -46,6 +46,8 @@ import play.api.http.MimeTypes
 import play.api.http.Status.ACCEPTED
 import play.api.http.Status.BAD_REQUEST
 import play.api.http.Status.INTERNAL_SERVER_ERROR
+import play.api.http.Status.NOT_FOUND
+import play.api.http.Status.OK
 import play.api.http.Status.UNSUPPORTED_MEDIA_TYPE
 import play.api.libs.Files.SingletonTemporaryFileCreator
 import play.api.libs.json.Json
@@ -72,9 +74,10 @@ import v2.models.errors.JsonValidationError
 import v2.models.errors.PersistenceError
 import v2.models.errors.RouterError
 import v2.models.errors.XmlValidationError
-import v2.models.errors.ConversionError
 import v2.models.request.MessageType
 import v2.models.responses.DeclarationResponse
+import v2.models.responses.MessageResponse
+import v2.models.responses.hateoas.HateoasDepartureMessageResponse
 import v2.services.AuditingService
 import v2.services.ConversionService
 import v2.services.DeparturesService
@@ -82,6 +85,8 @@ import v2.services.RouterService
 import v2.services.ValidationService
 
 import java.nio.charset.StandardCharsets
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -100,101 +105,9 @@ class V2DeparturesControllerSpec
     with TestSourceProvider
     with BeforeAndAfterEach {
 
-  // TODO: Make this a cc015c
   def CC015C: NodeSeq =
     <CC015C>
-      <SynIdeMES1>UNOC</SynIdeMES1>
-      <SynVerNumMES2>3</SynVerNumMES2>
-      <MesRecMES6>NCTS</MesRecMES6>
-      <DatOfPreMES9>20201217</DatOfPreMES9>
-      <TimOfPreMES10>1340</TimOfPreMES10>
-      <IntConRefMES11>17712576475433</IntConRefMES11>
-      <AppRefMES14>NCTS</AppRefMES14>
-      <MesIdeMES19>1</MesIdeMES19>
-      <MesTypMES20>GB015B</MesTypMES20>
-      <HEAHEA>
-        <RefNumHEA4>GUATEST1201217134032</RefNumHEA4>
-        <TypOfDecHEA24>T1</TypOfDecHEA24>
-        <CouOfDesCodHEA30>IT</CouOfDesCodHEA30>
-        <AutLocOfGooCodHEA41>954131533-GB60DEP</AutLocOfGooCodHEA41>
-        <CouOfDisCodHEA55>GB</CouOfDisCodHEA55>
-        <IdeOfMeaOfTraAtDHEA78>NC15 REG</IdeOfMeaOfTraAtDHEA78>
-        <NatOfMeaOfTraAtDHEA80>GB</NatOfMeaOfTraAtDHEA80>
-        <ConIndHEA96>0</ConIndHEA96>
-        <NCTSAccDocHEA601LNG>EN</NCTSAccDocHEA601LNG>
-        <TotNumOfIteHEA305>1</TotNumOfIteHEA305>
-        <TotNumOfPacHEA306>10</TotNumOfPacHEA306>
-        <TotGroMasHEA307>1000</TotGroMasHEA307>
-        <DecDatHEA383>20201217</DecDatHEA383>
-        <DecPlaHEA394>Dover</DecPlaHEA394>
-      </HEAHEA>
-      <TRAPRIPC1>
-        <NamPC17>NCTS UK TEST LAB HMCE</NamPC17>
-        <StrAndNumPC122>11TH FLOOR, ALEX HOUSE, VICTORIA AV</StrAndNumPC122>
-        <PosCodPC123>SS99 1AA</PosCodPC123>
-        <CitPC124>SOUTHEND-ON-SEA, ESSEX</CitPC124>
-        <CouPC125>GB</CouPC125>
-        <TINPC159>GB954131533000</TINPC159>
-      </TRAPRIPC1>
-      <TRACONCO1>
-        <NamCO17>NCTS UK TEST LAB HMCE</NamCO17>
-        <StrAndNumCO122>11TH FLOOR, ALEX HOUSE, VICTORIA AV</StrAndNumCO122>
-        <PosCodCO123>SS99 1AA</PosCodCO123>
-        <CitCO124>SOUTHEND-ON-SEA, ESSEX</CitCO124>
-        <CouCO125>GB</CouCO125>
-        <TINCO159>GB954131533000</TINCO159>
-      </TRACONCO1>
-      <TRACONCE1>
-        <NamCE17>NCTS UK TEST LAB HMCE</NamCE17>
-        <StrAndNumCE122>ITALIAN OFFICE</StrAndNumCE122>
-        <PosCodCE123>IT99 1IT</PosCodCE123>
-        <CitCE124>MILAN</CitCE124>
-        <CouCE125>IT</CouCE125>
-        <TINCE159>IT11ITALIANC11</TINCE159>
-      </TRACONCE1>
-      <CUSOFFDEPEPT>
-        <RefNumEPT1>GB000060</RefNumEPT1>
-      </CUSOFFDEPEPT>
-      <CUSOFFTRARNS>
-        <RefNumRNS1>FR001260</RefNumRNS1>
-        <ArrTimTRACUS085>202012191340</ArrTimTRACUS085>
-      </CUSOFFTRARNS>
-      <CUSOFFDESEST>
-        <RefNumEST1>IT018100</RefNumEST1>
-      </CUSOFFDESEST>
-      <CONRESERS>
-        <ConResCodERS16>A3</ConResCodERS16>
-        <DatLimERS69>20201225</DatLimERS69>
-      </CONRESERS>
-      <SEAINFSLI>
-        <SeaNumSLI2>1</SeaNumSLI2>
-        <SEAIDSID>
-          <SeaIdeSID1>NCTS001</SeaIdeSID1>
-        </SEAIDSID>
-      </SEAINFSLI>
-      <GUAGUA>
-        <GuaTypGUA1>0</GuaTypGUA1>
-        <GUAREFREF>
-          <GuaRefNumGRNREF1>20GB0000010000H72</GuaRefNumGRNREF1>
-          <AccCodREF6>AC01</AccCodREF6>
-        </GUAREFREF>
-      </GUAGUA>
-      <GOOITEGDS>
-        <IteNumGDS7>1</IteNumGDS7>
-        <GooDesGDS23>Wheat</GooDesGDS23>
-        <GooDesGDS23LNG>EN</GooDesGDS23LNG>
-        <GroMasGDS46>1000</GroMasGDS46>
-        <NetMasGDS48>950</NetMasGDS48>
-        <SPEMENMT2>
-          <AddInfMT21>20GB0000010000H72</AddInfMT21>
-          <AddInfCodMT23>CAL</AddInfCodMT23>
-        </SPEMENMT2>
-        <PACGS2>
-          <MarNumOfPacGS21>AB234</MarNumOfPacGS21>
-          <KinOfPacGS23>BX</KinOfPacGS23>
-          <NumOfPacGS24>10</NumOfPacGS24>
-        </PACGS2>
-      </GOOITEGDS>
+      <test>testxml</test>
     </CC015C>
 
   val CC015Cjson = Json.stringify(Json.obj("CC015" -> Json.obj("SynIdeMES1" -> "UNOC")))
@@ -324,7 +237,7 @@ class V2DeparturesControllerSpec
     )
 
   // Version 2
-  "with accept header set to application/vnd.hmrc.2.0+json (version two)" - {
+  "for a departure declaration with accept header set to application/vnd.hmrc.2.0+json (version two)" - {
     "with content type set to application/xml" - {
 
       // For the content length headers, we have to ensure that we send something
@@ -890,6 +803,66 @@ class V2DeparturesControllerSpec
       )
 
     }
+  }
+
+  "for retrieving a single message" - {
+
+    val dateTime = OffsetDateTime.of(2022, 8, 4, 11, 34, 42, 0, ZoneOffset.UTC)
+
+    "when the message is found" in {
+      val messageResponse = MessageResponse(
+        MessageId("0123456789abcdef"),
+        dateTime,
+        dateTime,
+        MessageType.DepartureDeclaration,
+        None,
+        None,
+        Some("<test></test>")
+      )
+      when(mockDeparturesPersistenceService.getMessage(EORINumber(any()), MovementId(any()), MessageId(any()))(any[HeaderCarrier], any[ExecutionContext]))
+        .thenAnswer(
+          _ => EitherT.rightT(messageResponse)
+        )
+
+      val request = FakeRequest("GET", "/", FakeHeaders(), Source.empty[ByteString])
+      val result  = sut.getMessage(MovementId("0123456789abcdef"), MessageId("0123456789abcdef"))(request)
+
+      status(result) mustBe OK
+      contentAsJson(result) mustBe Json.toJson(HateoasDepartureMessageResponse(MovementId("0123456789abcdef"), MessageId("0123456789abcdef"), messageResponse))
+    }
+
+    "when no message is found" in {
+      when(mockDeparturesPersistenceService.getMessage(EORINumber(any()), MovementId(any()), MessageId(any()))(any[HeaderCarrier], any[ExecutionContext]))
+        .thenAnswer(
+          _ => EitherT.leftT(PersistenceError.MessageNotFound(MovementId("0123456789abcdef"), MessageId("0123456789abcdef")))
+        )
+
+      val request = FakeRequest("GET", "/", FakeHeaders(), Source.empty[ByteString])
+      val result  = sut.getMessage(MovementId("0123456789abcdef"), MessageId("0123456789abcdef"))(request)
+
+      status(result) mustBe NOT_FOUND
+      contentAsJson(result) mustBe Json.obj(
+        "code"    -> "NOT_FOUND",
+        "message" -> "Message with ID 0123456789abcdef for movement 0123456789abcdef was not found"
+      )
+    }
+
+    "when an unknown error occurs" in {
+      when(mockDeparturesPersistenceService.getMessage(EORINumber(any()), MovementId(any()), MessageId(any()))(any[HeaderCarrier], any[ExecutionContext]))
+        .thenAnswer(
+          _ => EitherT.leftT(PersistenceError.UnexpectedError(thr = None))
+        )
+
+      val request = FakeRequest("GET", "/", FakeHeaders(), Source.empty[ByteString])
+      val result  = sut.getMessage(MovementId("0123456789abcdef"), MessageId("0123456789abcdef"))(request)
+
+      status(result) mustBe INTERNAL_SERVER_ERROR
+      contentAsJson(result) mustBe Json.obj(
+        "code"    -> "INTERNAL_SERVER_ERROR",
+        "message" -> "Internal server error"
+      )
+    }
+
   }
 
   def validateXmlOkStub(): OngoingStubbing[EitherT[Future, FailedToValidateError, Unit]] =

--- a/test/v2/fakes/controllers/FakeV1DepartureMessagesController.scala
+++ b/test/v2/fakes/controllers/FakeV1DepartureMessagesController.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.fakes.controllers
+
+import controllers.V1DepartureMessagesController
+import models.domain.DepartureId
+import models.domain.MessageId
+import play.api.libs.json.Json
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.BaseController
+import play.api.test.Helpers.stubControllerComponents
+
+class FakeV1DepartureMessagesController extends BaseController with V1DepartureMessagesController {
+  val controllerComponents = stubControllerComponents()
+
+  override def getDepartureMessage(departureId: DepartureId, messageId: MessageId): Action[AnyContent] = Action {
+    _ => Accepted(Json.obj("version" -> 1))
+  }
+}

--- a/test/v2/fakes/controllers/FakeV2DeparturesController.scala
+++ b/test/v2/fakes/controllers/FakeV2DeparturesController.scala
@@ -23,10 +23,13 @@ import akka.util.ByteString
 import com.google.inject.Inject
 import play.api.libs.json.Json
 import play.api.mvc.Action
+import play.api.mvc.AnyContent
 import play.api.mvc.BaseController
 import play.api.test.Helpers.stubControllerComponents
 import v2.controllers.V2DeparturesController
 import v2.controllers.stream.StreamingParsers
+import v2.models.MessageId
+import v2.models.MovementId
 
 class FakeV2DeparturesController @Inject() ()(implicit val materializer: Materializer)
     extends BaseController
@@ -41,4 +44,8 @@ class FakeV2DeparturesController @Inject() ()(implicit val materializer: Materia
       Accepted(Json.obj("version" -> 2))
   }
 
+  override def getMessage(departureId: MovementId, messageId: MessageId): Action[AnyContent] = Action {
+    _ =>
+      Accepted(Json.obj("version" -> 2))
+  }
 }

--- a/test/v2/fakes/controllers/FakeV2DeparturesController.scala
+++ b/test/v2/fakes/controllers/FakeV2DeparturesController.scala
@@ -29,7 +29,7 @@ import play.api.test.Helpers.stubControllerComponents
 import v2.controllers.V2DeparturesController
 import v2.controllers.stream.StreamingParsers
 import v2.models.MessageId
-import v2.models.MovementId
+import v2.models.DepartureId
 
 class FakeV2DeparturesController @Inject() ()(implicit val materializer: Materializer)
     extends BaseController
@@ -44,7 +44,7 @@ class FakeV2DeparturesController @Inject() ()(implicit val materializer: Materia
       Accepted(Json.obj("version" -> 2))
   }
 
-  override def getMessage(departureId: MovementId, messageId: MessageId): Action[AnyContent] = Action {
+  override def getMessage(departureId: DepartureId, messageId: MessageId): Action[AnyContent] = Action {
     _ =>
       Accepted(Json.obj("version" -> 2))
   }

--- a/test/v2/models/BindingsSpec.scala
+++ b/test/v2/models/BindingsSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.models
+
+import org.scalacheck.Gen
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import play.api.mvc.PathBindable
+
+class BindingsSpec extends AnyFreeSpec with Matchers with ScalaCheckDrivenPropertyChecks {
+
+  val testBinding: PathBindable[String] = Bindings.hexBinding(identity[String], identity[String])
+
+  val validHexString: Gen[String] = Gen.listOfN(16, Gen.hexChar).map(_.mkString.toLowerCase)
+
+  val tooShortHexString: Gen[String] = Gen
+    .chooseNum(1, 15)
+    .flatMap(
+      x => Gen.listOfN(x, Gen.hexChar)
+    )
+    .map(_.mkString.toLowerCase)
+
+  val tooLongHexString: Gen[String] = Gen
+    .chooseNum(17, 30)
+    .flatMap(
+      x => Gen.listOfN(x, Gen.hexChar)
+    )
+    .map(_.mkString.toLowerCase)
+  // Last character ensures it's not a hex string
+  val notAHexString: Gen[String] = Gen.listOfN(15, Gen.alphaNumChar).map(_.mkString.toLowerCase).map(_ + "x")
+
+  "hex binding" - {
+
+    "bind" - {
+      "a 16 character lowercase hex string must be accepted" in {
+        val value = validHexString.sample.getOrElse("1234567890123456")
+        testBinding.bind("test", value) mustBe Right(value)
+      }
+
+      "an invalid hex string must not be accepted" in Seq(tooShortHexString, tooLongHexString, notAHexString).foreach {
+        gen =>
+          val value = gen.sample.get
+          testBinding.bind("test", value) mustBe Left(s"test: Value $value is not a 16 character hexadecimal string")
+      }
+    }
+
+    "unbind" - {
+      val value = validHexString.sample.getOrElse("1234567890123456")
+      testBinding.unbind("test", value) mustBe value
+    }
+
+  }
+
+}

--- a/test/v2/models/DepartureIdSpec.scala
+++ b/test/v2/models/DepartureIdSpec.scala
@@ -23,16 +23,16 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import play.api.libs.json.JsString
 import play.api.libs.json.JsSuccess
 
-class MovementIdSpec extends AnyFreeSpec with Matchers with ScalaCheckDrivenPropertyChecks {
+class DepartureIdSpec extends AnyFreeSpec with Matchers with ScalaCheckDrivenPropertyChecks {
 
-  "when MovementId is serialized, return a JsString" in forAll(Gen.listOfN(16, Gen.hexChar).map(_.mkString.toLowerCase)) {
+  "when DepartureId is serialized, return a JsString" in forAll(Gen.listOfN(16, Gen.hexChar).map(_.mkString.toLowerCase)) {
     string =>
-      MovementId.movementIdFormat.writes(MovementId(string)) mustBe JsString(string)
+      DepartureId.departureIdFormat.writes(DepartureId(string)) mustBe JsString(string)
   }
 
-  "when JsString is deserialized, return a MessageId" in forAll(Gen.listOfN(16, Gen.hexChar).map(_.mkString.toLowerCase)) {
+  "when JsString is deserialized, return a DepartureId" in forAll(Gen.listOfN(16, Gen.hexChar).map(_.mkString.toLowerCase)) {
     string =>
-      MovementId.movementIdFormat.reads(JsString(string)) mustBe JsSuccess(MovementId(string))
+      DepartureId.departureIdFormat.reads(JsString(string)) mustBe JsSuccess(DepartureId(string))
   }
 
 }

--- a/test/v2/models/MessageIdSpec.scala
+++ b/test/v2/models/MessageIdSpec.scala
@@ -25,12 +25,12 @@ import play.api.libs.json.JsSuccess
 
 class MessageIdSpec extends AnyFreeSpec with Matchers with ScalaCheckDrivenPropertyChecks {
 
-  "when MessageID is serialized, return a JsString" in forAll(Gen.listOfN(10, Gen.alphaChar).map(_.mkString)) {
+  "when MessageID is serialized, return a JsString" in forAll(Gen.listOfN(16, Gen.hexChar).map(_.mkString)) {
     string =>
       MessageId.messageIdFormat.writes(MessageId(string)) mustBe JsString(string)
   }
 
-  "when JsString is deserialized, return a MessageId" in forAll(Gen.listOfN(10, Gen.alphaChar).map(_.mkString)) {
+  "when JsString is deserialized, return a MessageId" in forAll(Gen.listOfN(16, Gen.hexChar).map(_.mkString)) {
     string =>
       MessageId.messageIdFormat.reads(JsString(string)) mustBe JsSuccess(MessageId(string))
   }

--- a/test/v2/models/MovementIdSpec.scala
+++ b/test/v2/models/MovementIdSpec.scala
@@ -25,12 +25,12 @@ import play.api.libs.json.JsSuccess
 
 class MovementIdSpec extends AnyFreeSpec with Matchers with ScalaCheckDrivenPropertyChecks {
 
-  "when MovementId is serialized, return a JsString" in forAll(Gen.listOfN(10, Gen.alphaChar).map(_.mkString)) {
+  "when MovementId is serialized, return a JsString" in forAll(Gen.listOfN(16, Gen.hexChar).map(_.mkString.toLowerCase)) {
     string =>
       MovementId.movementIdFormat.writes(MovementId(string)) mustBe JsString(string)
   }
 
-  "when JsString is deserialized, return a MessageId" in forAll(Gen.listOfN(10, Gen.alphaChar).map(_.mkString)) {
+  "when JsString is deserialized, return a MessageId" in forAll(Gen.listOfN(16, Gen.hexChar).map(_.mkString.toLowerCase)) {
     string =>
       MovementId.movementIdFormat.reads(JsString(string)) mustBe JsSuccess(MovementId(string))
   }

--- a/test/v2/models/errors/PresentationErrorSpec.scala
+++ b/test/v2/models/errors/PresentationErrorSpec.scala
@@ -16,6 +16,7 @@
 
 package v2.models.errors
 
+import org.scalacheck.Gen
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.mockito.MockitoSugar
@@ -62,6 +63,19 @@ class PresentationErrorSpec extends AnyFreeSpec with Matchers with MockitoSugar 
           // then we should get an expected output
           json mustBe Json.obj("code" -> "INTERNAL_SERVER_ERROR", "message" -> "Internal server error")
         }
+    }
+
+    "for a binding bad request" in {
+      val gen          = Gen.alphaNumStr.sample.getOrElse("something")
+      val bindingError = PresentationError.bindingBadRequestError(gen)
+
+      val json = Json.toJson(bindingError)
+
+      json mustBe Json.obj(
+        "code"       -> "BAD_REQUEST",
+        "statusCode" -> 400,
+        "message"    -> gen
+      )
     }
 
     "for an upstream error" in {

--- a/test/v2/models/responses/DeclarationResponseSpec.scala
+++ b/test/v2/models/responses/DeclarationResponseSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package v2.models.response
+package v2.models.responses
 
 import org.scalacheck.Gen
 import org.scalatest.freespec.AnyFreeSpec

--- a/test/v2/models/responses/DeclarationResponseSpec.scala
+++ b/test/v2/models/responses/DeclarationResponseSpec.scala
@@ -22,9 +22,8 @@ import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import play.api.libs.json.JsSuccess
 import play.api.libs.json.Json
+import v2.models.DepartureId
 import v2.models.MessageId
-import v2.models.MovementId
-import v2.models.responses.DeclarationResponse
 
 class DeclarationResponseSpec extends AnyFreeSpec with Matchers with ScalaCheckDrivenPropertyChecks {
 
@@ -32,7 +31,7 @@ class DeclarationResponseSpec extends AnyFreeSpec with Matchers with ScalaCheckD
 
   "when MessageID is serialized, return an appropriate JsObject" in forAll(gen, gen) {
     (movement, message) =>
-      val actual   = DeclarationResponse.declarationResponseFormat.writes(DeclarationResponse(MovementId(movement), MessageId(message)))
+      val actual   = DeclarationResponse.declarationResponseFormat.writes(DeclarationResponse(DepartureId(movement), MessageId(message)))
       val expected = Json.obj("departureId" -> movement, "messageId" -> message)
       actual mustBe expected
   }
@@ -40,7 +39,7 @@ class DeclarationResponseSpec extends AnyFreeSpec with Matchers with ScalaCheckD
   "when an appropriate JsObject is deserialized, return a MessageId" in forAll(gen, gen) {
     (movement, message) =>
       val actual   = DeclarationResponse.declarationResponseFormat.reads(Json.obj("departureId" -> movement, "messageId" -> message))
-      val expected = DeclarationResponse(MovementId(movement), MessageId(message))
+      val expected = DeclarationResponse(DepartureId(movement), MessageId(message))
       actual mustBe JsSuccess(expected)
   }
 

--- a/test/v2/models/responses/MessageResponseSpec.scala
+++ b/test/v2/models/responses/MessageResponseSpec.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.models.responses
+
+import org.scalacheck.Gen
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import play.api.libs.json.JsSuccess
+import play.api.libs.json.Json
+import v2.models.MessageId
+import v2.models.request.MessageType
+
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+class MessageResponseSpec extends AnyFreeSpec with Matchers with ScalaCheckDrivenPropertyChecks {
+
+  private val hexId    = Gen.listOfN(16, Gen.hexChar).map(_.mkString.toLowerCase)
+  private val dateTime = OffsetDateTime.of(2022, 8, 4, 9, 59, 26, 0, ZoneOffset.UTC)
+
+  "when MessageResponse is serialized, return an appropriate JsObject" in {
+    val messageId = MessageId(hexId.sample.get)
+    val triggerId = MessageId(hexId.sample.get)
+    val body      = Gen.alphaNumStr.sample.get
+    val actual = MessageResponse.messageResponseFormat.writes(
+      MessageResponse(
+        messageId,
+        dateTime,
+        dateTime,
+        MessageType.DepartureDeclaration,
+        Some(triggerId),
+        None,
+        Some(body)
+      )
+    )
+    val expected = Json.obj(
+      "id"          -> messageId,
+      "received"    -> "2022-08-04T09:59:26Z", // due to OffsetDateTime in UTC
+      "generated"   -> "2022-08-04T09:59:26Z",
+      "messageType" -> "IE015",
+      "triggerId"   -> triggerId,
+      "body"        -> body
+    )
+    actual mustBe expected
+  }
+
+  "when an appropriate JsObject is deserialized, return a MessageResponse" in {
+    val messageId = MessageId(hexId.sample.get)
+    val triggerId = MessageId(hexId.sample.get)
+    val body      = Gen.alphaNumStr.sample.get
+    val expected =
+      MessageResponse(
+        messageId,
+        dateTime,
+        dateTime,
+        MessageType.DepartureDeclaration,
+        Some(triggerId),
+        None,
+        Some(body)
+      )
+    val actual = MessageResponse.messageResponseFormat.reads(
+      Json.obj(
+        "id"          -> messageId,
+        "received"    -> "2022-08-04T09:59:26Z",
+        "generated"   -> "2022-08-04T09:59:26Z",
+        "messageType" -> "IE015",
+        "triggerId"   -> triggerId,
+        "body"        -> body
+      )
+    )
+    actual mustBe JsSuccess(expected)
+  }
+
+}

--- a/test/v2/models/responses/hateoas/HateoasDepartureMessageResponseSpec.scala
+++ b/test/v2/models/responses/hateoas/HateoasDepartureMessageResponseSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.models.responses.hateoas
+
+import org.scalacheck.Gen
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import play.api.libs.json.Json
+import v2.models.MessageId
+import v2.models.MovementId
+import v2.models.request.MessageType
+import v2.models.responses.MessageResponse
+
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+class HateoasDepartureMessageResponseSpec extends AnyFreeSpec with Matchers with ScalaCheckDrivenPropertyChecks {
+
+  private val hexId    = Gen.listOfN(16, Gen.hexChar).map(_.mkString.toLowerCase)
+  private val dateTime = OffsetDateTime.of(2022, 8, 4, 11, 52, 59, 0, ZoneOffset.UTC)
+
+  "with a valid message response, create a valid HateoasDepartureMessageResponse" in {
+    val messageId   = MessageId(hexId.sample.get)
+    val departureId = MovementId(hexId.sample.get)
+    val triggerId   = MessageId(hexId.sample.get)
+    val body        = Gen.alphaNumStr.sample.get
+    val response = MessageResponse(
+      messageId,
+      dateTime,
+      dateTime,
+      MessageType.DepartureDeclaration,
+      Some(triggerId),
+      None,
+      Some(body)
+    )
+
+    val actual = HateoasDepartureMessageResponse(departureId, messageId, response)
+    val expected = Json.obj(
+      "_links" -> Json.obj(
+        "self"      -> Json.obj("href" -> s"/customs/transits/movements/departures/${departureId.value}/messages/${messageId.value}"),
+        "departure" -> Json.obj("href" -> s"/customs/transits/movements/departures/${departureId.value}")
+      ),
+      "departureId" -> departureId,
+      "messageId"   -> messageId,
+      "received"    -> "2022-08-04T11:52:59",
+      "messageType" -> MessageType.DepartureDeclaration.code,
+      "body"        -> body
+    )
+
+    actual mustBe expected
+  }
+
+}

--- a/test/v2/models/responses/hateoas/HateoasDepartureMessageResponseSpec.scala
+++ b/test/v2/models/responses/hateoas/HateoasDepartureMessageResponseSpec.scala
@@ -22,7 +22,7 @@ import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import play.api.libs.json.Json
 import v2.models.MessageId
-import v2.models.MovementId
+import v2.models.DepartureId
 import v2.models.request.MessageType
 import v2.models.responses.MessageResponse
 
@@ -36,7 +36,7 @@ class HateoasDepartureMessageResponseSpec extends AnyFreeSpec with Matchers with
 
   "with a valid message response, create a valid HateoasDepartureMessageResponse" in {
     val messageId   = MessageId(hexId.sample.get)
-    val departureId = MovementId(hexId.sample.get)
+    val departureId = DepartureId(hexId.sample.get)
     val triggerId   = MessageId(hexId.sample.get)
     val body        = Gen.alphaNumStr.sample.get
     val response = MessageResponse(

--- a/test/v2/services/DeparturesServiceSpec.scala
+++ b/test/v2/services/DeparturesServiceSpec.scala
@@ -21,13 +21,16 @@ import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.{eq => eqTo}
+import org.mockito.Mockito.reset
 import org.mockito.Mockito.when
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.OptionValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.http.Status.INTERNAL_SERVER_ERROR
+import play.api.http.Status.NOT_FOUND
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.UpstreamErrorResponse
 import v2.connectors.PersistenceConnector
@@ -35,16 +38,26 @@ import v2.models.EORINumber
 import v2.models.MessageId
 import v2.models.MovementId
 import v2.models.errors.PersistenceError
+import v2.models.request.MessageType
 import v2.models.responses.DeclarationResponse
+import v2.models.responses.MessageResponse
 
 import java.nio.charset.StandardCharsets
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class DeparturesServiceSpec extends AnyFreeSpec with Matchers with OptionValues with ScalaFutures with MockitoSugar {
+class DeparturesServiceSpec extends AnyFreeSpec with Matchers with OptionValues with ScalaFutures with MockitoSugar with BeforeAndAfterEach {
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
+
+  val mockConnector: PersistenceConnector = mock[PersistenceConnector]
+  val sut                                 = new DeparturesServiceImpl(mockConnector)
+
+  override def beforeEach(): Unit =
+    reset(mockConnector)
 
   "Submitting a Departure Declaration" - {
 
@@ -53,17 +66,9 @@ class DeparturesServiceSpec extends AnyFreeSpec with Matchers with OptionValues 
 
     val upstreamErrorResponse: Throwable = UpstreamErrorResponse("Internal service error", INTERNAL_SERVER_ERROR)
 
-    val mockConnector: PersistenceConnector = mock[PersistenceConnector]
-
-    // Because we're using AnyVal, Mockito doesn't really like it, so we have to put the underlying type down, then cast to the value type...
-    when(mockConnector.post(any[String].asInstanceOf[EORINumber], eqTo(validRequest))(any[HeaderCarrier], any[ExecutionContext]))
-      .thenReturn(Future.successful(DeclarationResponse(MovementId("ABC"), MessageId("123"))))
-    when(mockConnector.post(any[String].asInstanceOf[EORINumber], eqTo(invalidRequest))(any[HeaderCarrier], any[ExecutionContext]))
-      .thenReturn(Future.failed(upstreamErrorResponse))
-
-    val sut = new DeparturesServiceImpl(mockConnector)
-
     "on a successful submission, should return a Right" in {
+      when(mockConnector.post(EORINumber(any[String]), eqTo(validRequest))(any[HeaderCarrier], any[ExecutionContext]))
+        .thenReturn(Future.successful(DeclarationResponse(MovementId("ABC"), MessageId("123"))))
       val result                                                  = sut.saveDeclaration(EORINumber("1"), validRequest)
       val expected: Either[PersistenceError, DeclarationResponse] = Right(DeclarationResponse(MovementId("ABC"), MessageId("123")))
       whenReady(result.value) {
@@ -72,12 +77,61 @@ class DeparturesServiceSpec extends AnyFreeSpec with Matchers with OptionValues 
     }
 
     "on a failed submission, should return a Left with an UnexpectedError" in {
+      when(mockConnector.post(EORINumber(any[String]), eqTo(invalidRequest))(any[HeaderCarrier], any[ExecutionContext]))
+        .thenReturn(Future.failed(upstreamErrorResponse))
       val result                                                  = sut.saveDeclaration(EORINumber("1"), invalidRequest)
       val expected: Either[PersistenceError, DeclarationResponse] = Left(PersistenceError.UnexpectedError(Some(upstreamErrorResponse)))
       whenReady(result.value) {
         _ mustBe expected
       }
     }
+  }
+
+  "Getting a Single Message" - {
+
+    val now = OffsetDateTime.now(ZoneOffset.UTC)
+
+    "when a message is found, should return a Right" in {
+      val successResponse = MessageResponse(
+        MessageId("1234567890abcdef"),
+        now,
+        now,
+        MessageType.DepartureDeclaration,
+        None,
+        None,
+        Some("<test></test>")
+      )
+
+      when(mockConnector.getDepartureMessage(EORINumber(any()), MovementId(any()), MessageId(any()))(any(), any()))
+        .thenReturn(Future.successful(successResponse))
+
+      val result = sut.getMessage(EORINumber("1"), MovementId("1234567890abcdef"), MessageId("1234567890abcdef"))
+      whenReady(result.value) {
+        _ mustBe Right(successResponse)
+      }
+    }
+
+    "when a message is not found, should return a Left with an MessageNotFound" in {
+      when(mockConnector.getDepartureMessage(EORINumber(any()), MovementId(any()), MessageId(any()))(any(), any()))
+        .thenReturn(Future.failed(UpstreamErrorResponse("not found", NOT_FOUND)))
+
+      val result = sut.getMessage(EORINumber("1"), MovementId("1234567890abcdef"), MessageId("1234567890abcdef"))
+      whenReady(result.value) {
+        _ mustBe Left(PersistenceError.MessageNotFound(MovementId("1234567890abcdef"), MessageId("1234567890abcdef")))
+      }
+    }
+
+    "on a failed submission, should return a Left with an UnexpectedError" in {
+      val error = UpstreamErrorResponse("error", INTERNAL_SERVER_ERROR)
+      when(mockConnector.getDepartureMessage(EORINumber(any()), MovementId(any()), MessageId(any()))(any(), any()))
+        .thenReturn(Future.failed(error))
+
+      val result = sut.getMessage(EORINumber("1"), MovementId("1234567890abcdef"), MessageId("1234567890abcdef"))
+      whenReady(result.value) {
+        _ mustBe Left(PersistenceError.UnexpectedError(thr = Some(error)))
+      }
+    }
+
   }
 
 }

--- a/test/v2/services/DeparturesServiceSpec.scala
+++ b/test/v2/services/DeparturesServiceSpec.scala
@@ -36,7 +36,7 @@ import uk.gov.hmrc.http.UpstreamErrorResponse
 import v2.connectors.PersistenceConnector
 import v2.models.EORINumber
 import v2.models.MessageId
-import v2.models.MovementId
+import v2.models.DepartureId
 import v2.models.errors.PersistenceError
 import v2.models.request.MessageType
 import v2.models.responses.DeclarationResponse
@@ -68,9 +68,9 @@ class DeparturesServiceSpec extends AnyFreeSpec with Matchers with OptionValues 
 
     "on a successful submission, should return a Right" in {
       when(mockConnector.post(EORINumber(any[String]), eqTo(validRequest))(any[HeaderCarrier], any[ExecutionContext]))
-        .thenReturn(Future.successful(DeclarationResponse(MovementId("ABC"), MessageId("123"))))
+        .thenReturn(Future.successful(DeclarationResponse(DepartureId("ABC"), MessageId("123"))))
       val result                                                  = sut.saveDeclaration(EORINumber("1"), validRequest)
-      val expected: Either[PersistenceError, DeclarationResponse] = Right(DeclarationResponse(MovementId("ABC"), MessageId("123")))
+      val expected: Either[PersistenceError, DeclarationResponse] = Right(DeclarationResponse(DepartureId("ABC"), MessageId("123")))
       whenReady(result.value) {
         _ mustBe expected
       }
@@ -102,31 +102,31 @@ class DeparturesServiceSpec extends AnyFreeSpec with Matchers with OptionValues 
         Some("<test></test>")
       )
 
-      when(mockConnector.getDepartureMessage(EORINumber(any()), MovementId(any()), MessageId(any()))(any(), any()))
+      when(mockConnector.getDepartureMessage(EORINumber(any()), DepartureId(any()), MessageId(any()))(any(), any()))
         .thenReturn(Future.successful(successResponse))
 
-      val result = sut.getMessage(EORINumber("1"), MovementId("1234567890abcdef"), MessageId("1234567890abcdef"))
+      val result = sut.getMessage(EORINumber("1"), DepartureId("1234567890abcdef"), MessageId("1234567890abcdef"))
       whenReady(result.value) {
         _ mustBe Right(successResponse)
       }
     }
 
     "when a message is not found, should return a Left with an MessageNotFound" in {
-      when(mockConnector.getDepartureMessage(EORINumber(any()), MovementId(any()), MessageId(any()))(any(), any()))
+      when(mockConnector.getDepartureMessage(EORINumber(any()), DepartureId(any()), MessageId(any()))(any(), any()))
         .thenReturn(Future.failed(UpstreamErrorResponse("not found", NOT_FOUND)))
 
-      val result = sut.getMessage(EORINumber("1"), MovementId("1234567890abcdef"), MessageId("1234567890abcdef"))
+      val result = sut.getMessage(EORINumber("1"), DepartureId("1234567890abcdef"), MessageId("1234567890abcdef"))
       whenReady(result.value) {
-        _ mustBe Left(PersistenceError.MessageNotFound(MovementId("1234567890abcdef"), MessageId("1234567890abcdef")))
+        _ mustBe Left(PersistenceError.MessageNotFound(DepartureId("1234567890abcdef"), MessageId("1234567890abcdef")))
       }
     }
 
     "on a failed submission, should return a Left with an UnexpectedError" in {
       val error = UpstreamErrorResponse("error", INTERNAL_SERVER_ERROR)
-      when(mockConnector.getDepartureMessage(EORINumber(any()), MovementId(any()), MessageId(any()))(any(), any()))
+      when(mockConnector.getDepartureMessage(EORINumber(any()), DepartureId(any()), MessageId(any()))(any(), any()))
         .thenReturn(Future.failed(error))
 
-      val result = sut.getMessage(EORINumber("1"), MovementId("1234567890abcdef"), MessageId("1234567890abcdef"))
+      val result = sut.getMessage(EORINumber("1"), DepartureId("1234567890abcdef"), MessageId("1234567890abcdef"))
       whenReady(result.value) {
         _ mustBe Left(PersistenceError.UnexpectedError(thr = Some(error)))
       }

--- a/test/v2/services/RouterServiceSpec.scala
+++ b/test/v2/services/RouterServiceSpec.scala
@@ -33,7 +33,7 @@ import uk.gov.hmrc.http.UpstreamErrorResponse
 import v2.connectors.RouterConnector
 import v2.models.EORINumber
 import v2.models.MessageId
-import v2.models.MovementId
+import v2.models.DepartureId
 import v2.models.errors.RouterError
 import v2.models.request.MessageType
 
@@ -60,7 +60,7 @@ class RouterServiceSpec extends AnyFreeSpec with Matchers with OptionValues with
       mockConnector.post(
         any[MessageType],
         any[String].asInstanceOf[EORINumber],
-        any[String].asInstanceOf[MovementId],
+        any[String].asInstanceOf[DepartureId],
         any[String].asInstanceOf[MessageId],
         eqTo(validRequest)
       )(
@@ -74,7 +74,7 @@ class RouterServiceSpec extends AnyFreeSpec with Matchers with OptionValues with
       mockConnector.post(
         any[MessageType],
         any[String].asInstanceOf[EORINumber],
-        any[String].asInstanceOf[MovementId],
+        any[String].asInstanceOf[DepartureId],
         any[String].asInstanceOf[MessageId],
         eqTo(invalidRequest)
       )(
@@ -87,7 +87,7 @@ class RouterServiceSpec extends AnyFreeSpec with Matchers with OptionValues with
     val sut = new RouterServiceImpl(mockConnector)
 
     "on a successful submission, should return a Right" in {
-      val result                              = sut.send(MessageType.DepartureDeclaration, EORINumber("1"), MovementId("1"), MessageId("1"), validRequest)
+      val result                              = sut.send(MessageType.DepartureDeclaration, EORINumber("1"), DepartureId("1"), MessageId("1"), validRequest)
       val expected: Either[RouterError, Unit] = Right(())
       whenReady(result.value) {
         _ mustBe expected
@@ -95,7 +95,7 @@ class RouterServiceSpec extends AnyFreeSpec with Matchers with OptionValues with
     }
 
     "on a failed submission, should return a Left with an UnexpectedError" in {
-      val result                              = sut.send(MessageType.DepartureDeclaration, EORINumber("1"), MovementId("1"), MessageId("1"), invalidRequest)
+      val result                              = sut.send(MessageType.DepartureDeclaration, EORINumber("1"), DepartureId("1"), MessageId("1"), invalidRequest)
       val expected: Either[RouterError, Unit] = Left(RouterError.UnexpectedError(Some(upstreamErrorResponse)))
       whenReady(result.value) {
         _ mustBe expected


### PR DESCRIPTION
Draft for the moment. This PR updates the `GET /customs/transits/movements/departures/:departureId/messages/:messageId` endpoint to accept version 2.

This PR:

- [x] Adds binders for MessageId and MovementId to only accept 16 character hex strings in the URL
- [x] Adds routing between the two versions of the GET endpoint
- [x] Adds the logic behind the version 2 endpoint

Note that for the binding, I have ensured that the `statusCode` field has remained if we can't bind to a parameter, as that is what we currently send, along with a message. I have added the "code" field too, which will bring it inline with our other messages - due to this being an addition, I think this probably isn't going to be a breaking change in v1, but I'm open (and still considering!) to changing it there to match what Play does.