### PR TITLE
CTCP-773: Fix routing to V1 GET/DELETE endpoints when a content type is defined

### DIFF
--- a/test/routing/VersionedRoutingSpec.scala
+++ b/test/routing/VersionedRoutingSpec.scala
@@ -19,23 +19,27 @@ package routing
 import akka.NotUsed
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
-import akka.stream.testkit.NoMaterializer
 import akka.util.ByteString
+import org.scalatest.OptionValues
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import play.api.Logging
 import play.api.http.HeaderNames
+import play.api.http.HttpVerbs
 import play.api.http.MimeTypes
 import play.api.http.Status.BAD_REQUEST
 import play.api.http.Status.UNSUPPORTED_MEDIA_TYPE
 import play.api.libs.json.Json
 import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.AnyContentAsEmpty
 import play.api.mvc.ControllerComponents
+import play.api.test.DefaultAwaitTimeout
 import play.api.test.FakeHeaders
 import play.api.test.FakeRequest
 import play.api.test.Helpers.contentAsJson
 import play.api.test.Helpers.contentAsString
-import play.api.test.Helpers.defaultAwaitTimeout
 import play.api.test.Helpers.status
 import play.api.test.Helpers.stubControllerComponents
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
@@ -43,11 +47,16 @@ import v2.base.TestActorSystem
 import v2.controllers.stream.StreamingParsers
 
 import java.nio.charset.StandardCharsets
-import scala.collection.immutable
 import scala.concurrent.Future
 import scala.xml.NodeSeq
 
-class VersionedRoutingSpec extends AnyFreeSpec with Matchers with TestActorSystem {
+class VersionedRoutingSpec
+    extends AnyFreeSpec
+    with Matchers
+    with TestActorSystem
+    with ScalaCheckDrivenPropertyChecks
+    with OptionValues
+    with DefaultAwaitTimeout {
 
   class Harness(cc: ControllerComponents)(implicit val materializer: Materializer)
       extends BackendController(cc)
@@ -55,26 +64,65 @@ class VersionedRoutingSpec extends AnyFreeSpec with Matchers with TestActorSyste
       with StreamingParsers
       with Logging {
 
-    def test: Action[Source[ByteString, _]] = route {
+    def testWithContent: Action[Source[ByteString, _]] = route {
+      case Some("application/vnd.hmrc.2.0+json") => contentActionTwo
+      case Some(x) if x != MimeTypes.TEXT        => contentActionOne
+    }
+
+    def contentActionOne: Action[NodeSeq] = Action.async(parse.xml) {
+      _ => Future.successful(Ok("One"))
+    }
+
+    def contentActionTwo: Action[NodeSeq] = Action.async(parse.xml) {
+      _ => Future.successful(Ok("Two"))
+    }
+
+    def testWithoutContent: Action[Source[ByteString, _]] = route {
       case Some("application/vnd.hmrc.2.0+json") => actionTwo
       case Some(x) if x != MimeTypes.TEXT        => actionOne
     }
 
-    def actionOne: Action[NodeSeq] = Action.async(parse.xml) {
-      _ => Future.successful(Ok("One"))
+    def actionOne: Action[AnyContent] = Action {
+      request =>
+        request.headers.get(CONTENT_TYPE) match {
+          case Some(x) => UnsupportedMediaType(s"Content type was set: $x")
+          case None    => Ok("One")
+        }
     }
 
-    def actionTwo: Action[NodeSeq] = Action.async(parse.xml) {
-      _ => Future.successful(Ok("Two"))
+    def actionTwo: Action[AnyContent] = Action {
+      request =>
+        request.headers.get(CONTENT_TYPE) match {
+          case Some(x) => UnsupportedMediaType(s"Content type was set: $x")
+          case None    => Ok("Two")
+        }
     }
   }
 
   private def generateSource(string: String): Source[ByteString, NotUsed] =
-    Source(ByteString.fromString(string, StandardCharsets.UTF_8).grouped(1024).to[immutable.Iterable])
+    Source.fromIterator(
+      () => ByteString.fromString(string, StandardCharsets.UTF_8).grouped(1024)
+    )
 
   "VersionRouting" - {
 
-    Seq(Some("application/vnd.hmrc.1.0+json"), Some("text/html"), Some("application/vnd.hmrc.1.0+xml"), Some("text/javascript")).foreach {
+    val methodsWithBody = Seq(
+      HttpVerbs.POST,
+      HttpVerbs.PUT,
+      HttpVerbs.PATCH
+    )
+
+    val methodsWithoutBody = Seq(
+      HttpVerbs.GET,
+      HttpVerbs.DELETE,
+      HttpVerbs.HEAD,
+      HttpVerbs.OPTIONS
+    )
+
+    val headers =
+      Seq(Some("application/vnd.hmrc.1.0+json"), Some("text/html"), Some("application/vnd.hmrc.1.0+xml"), Some("text/javascript"))
+
+    headers.foreach {
       acceptHeaderValue =>
         val acceptHeader = acceptHeaderValue
           .map(
@@ -86,14 +134,53 @@ class VersionedRoutingSpec extends AnyFreeSpec with Matchers with TestActorSyste
           .getOrElse("nothing")
         s"with accept header set to $withString" - {
 
-          "must call correct action" in {
-            val cc  = stubControllerComponents()
-            val sut = new Harness(cc)
+          "must call correct action with a body" - methodsWithBody.foreach {
+            method =>
+              s"for method $method" in {
+                val cc  = stubControllerComponents()
+                val sut = new Harness(cc)
 
-            val request = FakeRequest("GET", "/", departureHeaders, generateSource("<test>test</test>"))
+                // I know this shouldn't work for get, but it should drain it and work
+                val request = FakeRequest(method, "/", departureHeaders, generateSource("<test>test</test>"))
 
-            val result = sut.test()(request)
-            contentAsString(result)(defaultAwaitTimeout, NoMaterializer) mustBe "One"
+                val result = sut.testWithContent()(request)
+                contentAsString(result) mustBe "One"
+              }
+          }
+
+          "must call correct action without a body" - methodsWithoutBody.foreach {
+            method =>
+              Seq(Some(MimeTypes.XML), Some(MimeTypes.JSON), None).foreach {
+                contentType =>
+                  val headersWithoutBody = FakeHeaders(
+                    acceptHeader ++ contentType
+                      .map(
+                        x => Seq(HeaderNames.CONTENT_TYPE -> x)
+                      )
+                      .getOrElse(Seq.empty)
+                  )
+                  s"for method $method with content type $contentType" in {
+                    val cc      = stubControllerComponents()
+                    val sut     = new Harness(cc)
+                    val request = FakeRequest(method, "/", headersWithoutBody, AnyContentAsEmpty)
+
+                    val result = sut.testWithoutContent()(request)
+                    contentAsString(result) mustBe "One"
+                  }
+              }
+          }
+
+          "must cause failures if we send an HTTP method that doesn't support request bodies" - methodsWithoutBody.foreach {
+            method =>
+              s"for method $method" in {
+                val cc  = stubControllerComponents()
+                val sut = new Harness(cc)
+
+                val request = FakeRequest(method, "/", departureHeaders, generateSource("<test>test</test>"))
+
+                val result = sut.testWithContent()(request)
+                status(result) mustBe UNSUPPORTED_MEDIA_TYPE
+              }
           }
         }
     }
@@ -102,15 +189,27 @@ class VersionedRoutingSpec extends AnyFreeSpec with Matchers with TestActorSyste
 
       val departureHeaders = FakeHeaders(Seq(HeaderNames.ACCEPT -> "application/vnd.hmrc.2.0+json", HeaderNames.CONTENT_TYPE -> "application/xml"))
 
-      "must call correct action" in {
+      "must call correct action without body" in {
 
         val cc  = stubControllerComponents()
         val sut = new Harness(cc)
 
-        val request = FakeRequest("GET", "/", departureHeaders, generateSource("<test>test</test>"))
+        val request = FakeRequest(HttpVerbs.GET, "/", departureHeaders, AnyContentAsEmpty)
 
-        val result = sut.test()(request)
-        contentAsString(result)(defaultAwaitTimeout, NoMaterializer) mustBe "Two"
+        val result = sut.testWithoutContent()(request)
+        contentAsString(result) mustBe "Two"
+
+      }
+
+      "must call correct action with body" in {
+
+        val cc  = stubControllerComponents()
+        val sut = new Harness(cc)
+
+        val request = FakeRequest(HttpVerbs.POST, "/", departureHeaders, generateSource("<test>test</test>"))
+
+        val result = sut.testWithContent()(request)
+        contentAsString(result) mustBe "Two"
 
       }
     }
@@ -125,7 +224,7 @@ class VersionedRoutingSpec extends AnyFreeSpec with Matchers with TestActorSyste
 
         val request = FakeRequest("GET", "/", departureHeaders, generateSource("<test>test</test>"))
 
-        val result = sut.test()(request)
+        val result = sut.testWithContent()(request)
         status(result) mustBe UNSUPPORTED_MEDIA_TYPE
         Json.parse(contentAsString(result)) mustBe Json.obj(
           "code"    -> "UNSUPPORTED_MEDIA_TYPE",
@@ -140,9 +239,9 @@ class VersionedRoutingSpec extends AnyFreeSpec with Matchers with TestActorSyste
         val cc  = stubControllerComponents()
         val sut = new Harness(cc)
 
-        val request = FakeRequest("GET", "/", departureHeaders, generateSource("<test>test</test>"))
+        val request = FakeRequest(HttpVerbs.POST, "/", departureHeaders, generateSource("<test>test</test>"))
 
-        val result = sut.test()(request)
+        val result = sut.testWithContent()(request)
         status(result) mustBe UNSUPPORTED_MEDIA_TYPE
         Json.parse(contentAsString(result)) mustBe Json.obj(
           "code"    -> "UNSUPPORTED_MEDIA_TYPE",
@@ -159,7 +258,7 @@ class VersionedRoutingSpec extends AnyFreeSpec with Matchers with TestActorSyste
 
       val sut = new Harness(stubControllerComponents())
 
-      val request = FakeRequest("GET", "/", FakeHeaders(), generateSource("<test>test</test>"))
+      val request = FakeRequest(HttpVerbs.POST, "/", FakeHeaders(), generateSource("<test>test</test>"))
       val action  = sut.bindingFailureAction("failed")
       val result  = action(request)
 


### PR DESCRIPTION
If we directly invoke the action via a GET endpoint with a content type, Play correctly parses the body as empty. However, it seems when chaining the actions, Play will use the content type and try to parse an empty body. To sidestep this, we drain the request body (which should be empty anyway) and manually remove the content type so that the GET endpoints don't try to parse things as the content type suggests.