### PR TITLE
CTCP-832: Fix returned datetime in receivedSince parameter for the Message IDs response

### DIFF
--- a/app/models/Binders.scala
+++ b/app/models/Binders.scala
@@ -31,4 +31,8 @@ object Binders {
       (param, _) => s"Cannot parse parameter $param as a valid ISO 8601 timestamp, e.g. 2015-09-08T01:55:28+00:00"
     )
   }
+
+  // needed for the reverse routing
+  implicit val optionOffsetDateTimeQueryStringBindable: QueryStringBindable[Option[OffsetDateTime]] =
+    QueryStringBindable.bindableOption[OffsetDateTime]
 }

--- a/app/v2/models/responses/hateoas/HateoasResponse.scala
+++ b/app/v2/models/responses/hateoas/HateoasResponse.scala
@@ -22,7 +22,6 @@ import v2.models.MessageId
 import v2.models.responses.hateoas.HateoasResponse.prefix
 
 import java.time.OffsetDateTime
-import java.time.temporal.ChronoUnit
 
 object HateoasResponse {
 
@@ -41,9 +40,7 @@ trait HateoasResponse {
     prefix + routing.routes.DeparturesRouter
       .getMessageIds(
         departureId.value,
-        receivedSince.map(
-          x => x.truncatedTo(ChronoUnit.SECONDS)
-        )
+        receivedSince
       )
       .url
 

--- a/test/v2/connectors/V2BaseConnectorSpec.scala
+++ b/test/v2/connectors/V2BaseConnectorSpec.scala
@@ -48,9 +48,6 @@ import v2.models.EORINumber
 import v2.models.MessageId
 import v2.models.request.MessageType
 
-import java.time.OffsetDateTime
-import java.time.ZoneOffset
-import java.time.format.DateTimeFormatter
 import scala.concurrent.ExecutionContext.Implicits._
 import scala.concurrent.Future
 

--- a/test/v2/models/responses/hateoas/HateoasDepartureMessageIdsResponseSpec.scala
+++ b/test/v2/models/responses/hateoas/HateoasDepartureMessageIdsResponseSpec.scala
@@ -28,7 +28,7 @@ import v2.models.DepartureId
 import v2.models.MessageId
 
 import java.time.OffsetDateTime
-import java.time.temporal.ChronoUnit
+import java.time.format.DateTimeFormatter
 
 class HateoasDepartureMessageIdsResponseSpec extends AnyFreeSpec with Matchers with ScalaCheckDrivenPropertyChecks with OptionValues with CommonGenerators {
 
@@ -70,8 +70,9 @@ class HateoasDepartureMessageIdsResponseSpec extends AnyFreeSpec with Matchers w
 
   private def selfUrl(departureId: DepartureId, dateTime: Option[OffsetDateTime]): JsObject = dateTime match {
     case Some(x) =>
+      val time = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(x)
       Json.obj(
-        "href" -> s"/customs/transits/movements/departures/${departureId.value}/messages?receivedSince=${x.truncatedTo(ChronoUnit.SECONDS)}"
+        "href" -> s"/customs/transits/movements/departures/${departureId.value}/messages?receivedSince=$time"
       )
     case None => Json.obj("href" -> s"/customs/transits/movements/departures/${departureId.value}/messages")
   }


### PR DESCRIPTION
Caught this when writing a regression test.

The implict binding for `OffsetDateTime` didn't work when trying to get a URL from the reverse routing because the system was looking for an implicit `PathBindable[Option[OffsetDateTime]]` -- the one that was found was the standard one which doesn't format to the ISO date time.

We have to explicity provide an implicit thanks to Play's Macro expansions.

Test updated to reflect what we really wanted.