### PR TITLE
CTCP-1205: Add X-Message-Type header to messages sent to the router

### DIFF
--- a/app/config/Constants.scala
+++ b/app/config/Constants.scala
@@ -25,7 +25,8 @@ object Constants {
 
   val Context = "/customs/transits"
 
-  val XClientIdHeader = "X-Client-Id"
+  val XClientIdHeader    = "X-Client-Id"
+  val XMessageTypeHeader = "X-Message-Type"
 
   val ChannelHeader = "channel"
 

--- a/app/v2/connectors/RouterConnector.scala
+++ b/app/v2/connectors/RouterConnector.scala
@@ -22,6 +22,7 @@ import com.google.inject.ImplementedBy
 import com.google.inject.Inject
 import com.kenshoo.play.metrics.Metrics
 import config.AppConfig
+import config.Constants
 import metrics.HasMetrics
 import metrics.MetricsKeys
 import play.api.Logging
@@ -64,7 +65,7 @@ class RouterConnectorImpl @Inject() (val metrics: Metrics, appConfig: AppConfig,
 
         httpClientV2
           .post(url"$url")
-          .addHeaders(HeaderNames.CONTENT_TYPE -> MimeTypes.XML)
+          .addHeaders(HeaderNames.CONTENT_TYPE -> MimeTypes.XML, Constants.XMessageTypeHeader -> messageType.code)
           .withBody(body)
           .executeAccepted
     }

--- a/it/v2/connectors/RouterConnectorSpec.scala
+++ b/it/v2/connectors/RouterConnectorSpec.scala
@@ -24,6 +24,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.equalTo
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import config.AppConfig
+import config.Constants
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
 import org.scalatest.concurrent.IntegrationPatience
@@ -93,6 +94,7 @@ class RouterConnectorSpec
             urlEqualTo(targetUrl(eoriNumber, messageType, movementId, messageId))
           )
             .withHeader(HeaderNames.CONTENT_TYPE, equalTo(MimeTypes.XML))
+            .withHeader(Constants.XMessageTypeHeader, equalTo(messageType.code))
             .willReturn(aResponse().withStatus(ACCEPTED))
         )
 
@@ -124,6 +126,7 @@ class RouterConnectorSpec
             urlEqualTo(targetUrl(eoriNumber, messageType, movementId, messageId))
           )
             .withHeader(HeaderNames.CONTENT_TYPE, equalTo(MimeTypes.XML))
+            .withHeader(Constants.XMessageTypeHeader, equalTo(messageType.code))
             .willReturn(
               aResponse()
                 .withStatus(INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
A stop gap so we can potentially unblock CTCP-1205 -- may be superseded by CTCP-1207.