### PR TITLE
CTCP-1512: Fix incorrect name for IE170

### DIFF
--- a/app/v2/models/AuditType.scala
+++ b/app/v2/models/AuditType.scala
@@ -21,31 +21,31 @@ sealed abstract class AuditType(val name: String)
 object AuditType {
 
   // IE015
-  case object AmendmentAcceptance                             extends AuditType("AmendmentAcceptance")
-  case object InvalidationDecision                            extends AuditType("InvalidationDecision")
-  case object DeclarationAmendment                            extends AuditType("DeclarationAmendment")
-  case object DeclarationInvalidationRequest                  extends AuditType("DeclarationInvalidationRequest")
-  case object DeclarationData                                 extends AuditType("DeclarationData")
-  case object Discrepancies                                   extends AuditType("Discrepancies")
-  case object MRNAllocated                                    extends AuditType("MRNAllocated")
-  case object ReleaseForTransit                               extends AuditType("ReleaseForTransit")
-  case object RecoveryNotification                            extends AuditType("RecoveryNotification")
-  case object WriteOffNotification                            extends AuditType("WriteOffNotification")
-  case object NoReleaseForTransit                             extends AuditType("NoReleaseForTransit")
-  case object RequestOfRelease                                extends AuditType("RequestOfRelease")
-  case object GuaranteeNotValid                               extends AuditType("GuaranteeNotValid")
-  case object RejectionFromOfficeOfDeparture                  extends AuditType("RejectionFromOfficeOfDeparture")
-  case object ControlDecisionNotification                     extends AuditType("ControlDecisionNotification")
-  case object PresentationNotificationForThePreLodgedDecision extends AuditType("PresentationNotificationForThePreLodgedDecision")
-  case object FunctionalNack                                  extends AuditType("FunctionalNack")
-  case object PositiveAcknowledge                             extends AuditType("PositiveAcknowledge")
-  case object ArrivalNotification                             extends AuditType("ArrivalNotification")
+  case object AmendmentAcceptance                                extends AuditType("AmendmentAcceptance")
+  case object InvalidationDecision                               extends AuditType("InvalidationDecision")
+  case object DeclarationAmendment                               extends AuditType("DeclarationAmendment")
+  case object DeclarationInvalidationRequest                     extends AuditType("DeclarationInvalidationRequest")
+  case object DeclarationData                                    extends AuditType("DeclarationData")
+  case object Discrepancies                                      extends AuditType("Discrepancies")
+  case object MRNAllocated                                       extends AuditType("MRNAllocated")
+  case object ReleaseForTransit                                  extends AuditType("ReleaseForTransit")
+  case object RecoveryNotification                               extends AuditType("RecoveryNotification")
+  case object WriteOffNotification                               extends AuditType("WriteOffNotification")
+  case object NoReleaseForTransit                                extends AuditType("NoReleaseForTransit")
+  case object RequestOfRelease                                   extends AuditType("RequestOfRelease")
+  case object GuaranteeNotValid                                  extends AuditType("GuaranteeNotValid")
+  case object RejectionFromOfficeOfDeparture                     extends AuditType("RejectionFromOfficeOfDeparture")
+  case object ControlDecisionNotification                        extends AuditType("ControlDecisionNotification")
+  case object PresentationNotificationForThePreLodgedDeclaration extends AuditType("PresentationNotificationForThePreLodgedDecision")
+  case object FunctionalNack                                     extends AuditType("FunctionalNack")
+  case object PositiveAcknowledge                                extends AuditType("PositiveAcknowledge")
+  case object ArrivalNotification                                extends AuditType("ArrivalNotification")
 
   val values: Seq[AuditType] = Seq(
     DeclarationData,
     DeclarationAmendment,
     DeclarationInvalidationRequest,
-    PresentationNotificationForThePreLodgedDecision,
+    PresentationNotificationForThePreLodgedDeclaration,
     RequestOfRelease
   )
 

--- a/app/v2/models/request/MessageType.scala
+++ b/app/v2/models/request/MessageType.scala
@@ -55,8 +55,8 @@ object MessageType {
   case object RejectionFromOfficeOfDeparture extends DepartureMessageType("IE056", "CC056C", AuditType.RejectionFromOfficeOfDeparture)
   case object ControlDecisionNotification    extends DepartureMessageType("IE060", "CC060C", AuditType.ControlDecisionNotification)
 
-  case object PresentationNotificationForThePreLodgedDecision
-      extends DepartureMessageType("IE170", "CC170C", AuditType.PresentationNotificationForThePreLodgedDecision)
+  case object PresentationNotificationForThePreLodgedDeclaration
+      extends DepartureMessageType("IE170", "CC170C", AuditType.PresentationNotificationForThePreLodgedDeclaration)
   case object FunctionalNack      extends DepartureMessageType("IE906", "CC906C", AuditType.FunctionalNack)      // TODO: This is also an arrival message
   case object PositiveAcknowledge extends DepartureMessageType("IE928", "CC928C", AuditType.PositiveAcknowledge) // TODO: This is also an arrival message
 
@@ -66,7 +66,7 @@ object MessageType {
     DeclarationAmendment,
     DeclarationInvalidationRequest,
     RequestOfRelease,
-    PresentationNotificationForThePreLodgedDecision
+    PresentationNotificationForThePreLodgedDeclaration
   )
 
   val messageTypeSentToDepartureTrader: Seq[MessageType] = Seq(


### PR DESCRIPTION
This corrects the name for the IE170, and in turn, will not cause the auditing service to return a 400.