### PR TITLE
CTCP-1539: Spike to show we can merge streams using Akka to stream large XML responses out in Json

### DIFF
--- a/app/v2/utils/StreamingUtils.scala
+++ b/app/v2/utils/StreamingUtils.scala
@@ -66,7 +66,7 @@ object StreamingUtils extends ErrorTranslator {
       Source.single(ByteString(s""""$fieldName":"""".stripMargin)) ++
       // our XML stream that we escape
       stream.map(
-        bs => ByteString(bs.utf8String.replace("\"", "\\\""))
+        bs => ByteString(bs.utf8String.replace(raw"\", raw"\\").replace("\"", "\\\""))
       ) ++
       // and the stream that ends our Json document
       END_TOKEN_SOURCE

--- a/test/v2/utils/StreamingUtilsSpec.scala
+++ b/test/v2/utils/StreamingUtilsSpec.scala
@@ -97,7 +97,7 @@ class StreamingUtilsSpec extends AnyFreeSpec with Matchers with MockitoSugar wit
           )
         )
 
-        val sampleXML = """<ncts:CC004C PhaseID="NCTS5.0" xmlns:ncts="http://ncts.dgtaxud.ec"><messageRecipient>3YDhC2ur8ES</messageRecipient></ncts:CC004C>"""
+        val sampleXML = """<ncts:CC004C PhaseID="NCTS5.0" xmlns:ncts="http://ncts.dgtaxud.ec"><messageRecipient>3YDhC\2ur8ES</messageRecipient></ncts:CC004C>"""
 
         val stream: Source[ByteString, _] = Source.single(ByteString(sampleXML))
 

--- a/test/v2/utils/StreamingUtilsSpec.scala
+++ b/test/v2/utils/StreamingUtilsSpec.scala
@@ -24,6 +24,7 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.json.JsNumber
+import play.api.libs.json.JsNumber
 import play.api.libs.json.JsString
 import play.api.libs.json.JsValue
 import play.api.libs.json.Json
@@ -54,9 +55,9 @@ class StreamingUtilsSpec extends AnyFreeSpec with Matchers with MockitoSugar wit
 
       "when providing a stream should produce expected Json" in {
 
-        val fields = Seq[(String, JsValue)](
-          "a" -> JsString("b"),
-          "b" -> JsNumber(1),
+        val json = Json.obj(
+          "a" -> "b",
+          "b" -> 1,
           "c" -> Json.obj(
             "d" -> 1,
             "e" -> "f"
@@ -65,7 +66,7 @@ class StreamingUtilsSpec extends AnyFreeSpec with Matchers with MockitoSugar wit
 
         val stream: Source[ByteString, _] = Source.single(ByteString("abc"))
 
-        val resultStream = StreamingUtils.mergeStreamIntoJson(fields, "body", stream)
+        val resultStream = StreamingUtils.mergeStreamIntoJson(json.fields, "body", stream)
         val res = resultStream
           .reduce(_ ++ _)
           .map(


### PR DESCRIPTION
**Not for merging**

This spike simply shows that we can create a Json blob that contains a large XML blob, useful for our JSON+XML GET representations. We have to do a bit of manual building of the Json, but it's not all that much. We also have to consider escaping the XML, but as we can chunk that via the stream, it's not a horrible merge it all together, escape, and rechunk it deal, we can do it as the ByteString chunks get streamed through.

We could probably tidy the implementation up, but this at least proves we can do it. The test with XML shows that Play's Json parsers will parse the XML correctly, removing the escaping -- which means we're doing what Play Json would do.