### PR TITLE
CTCP-1682: Enable passthrough of updatedSince parameter for get movement by EORI endpoints

### DIFF
--- a/app/v2/controllers/V2ArrivalsController.scala
+++ b/app/v2/controllers/V2ArrivalsController.scala
@@ -26,7 +26,6 @@ import com.google.inject.Singleton
 import com.kenshoo.play.metrics.Metrics
 import metrics.HasActionMetrics
 import play.api.Logging
-import play.api.http.HeaderNames
 import play.api.http.MimeTypes
 import play.api.libs.Files.TemporaryFileCreator
 import play.api.libs.json.Json
@@ -152,7 +151,7 @@ class V2ArrivalsControllerImpl @Inject() (
         implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
 
         arrivalsService
-          .getArrivalsForEori(request.eoriNumber)
+          .getArrivalsForEori(request.eoriNumber, updatedSince)
           .asPresentation
           .fold(
             presentationError => Status(presentationError.code.statusCode)(Json.toJson(presentationError)),

--- a/app/v2/controllers/V2DeparturesController.scala
+++ b/app/v2/controllers/V2DeparturesController.scala
@@ -216,7 +216,7 @@ class V2DeparturesControllerImpl @Inject() (
         implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
 
         departuresService
-          .getDeparturesForEori(request.eoriNumber)
+          .getDeparturesForEori(request.eoriNumber, updatedSince)
           .asPresentation
           .fold(
             presentationError => Status(presentationError.code.statusCode)(Json.toJson(presentationError)),

--- a/app/v2/services/ArrivalsService.scala
+++ b/app/v2/services/ArrivalsService.scala
@@ -57,7 +57,7 @@ trait ArrivalsService {
     ec: ExecutionContext
   ): EitherT[Future, PersistenceError, Seq[MessageSummary]]
 
-  def getArrivalsForEori(eori: EORINumber)(implicit
+  def getArrivalsForEori(eori: EORINumber, updatedSince: Option[OffsetDateTime])(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
   ): EitherT[Future, PersistenceError, Seq[MovementResponse]]
@@ -126,12 +126,12 @@ class ArrivalsServiceImpl @Inject() (persistenceConnector: PersistenceConnector)
         }
     )
 
-  override def getArrivalsForEori(eori: EORINumber)(implicit
+  override def getArrivalsForEori(eori: EORINumber, updatedSince: Option[OffsetDateTime])(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
   ): EitherT[Future, PersistenceError, Seq[MovementResponse]] = EitherT(
     persistenceConnector
-      .getArrivalsForEori(eori)
+      .getArrivalsForEori(eori, updatedSince)
       .map(Right(_))
       .recover {
         case UpstreamErrorResponse(_, NOT_FOUND, _, _) => Left(PersistenceError.ArrivalsNotFound(eori))

--- a/app/v2/services/DeparturesService.scala
+++ b/app/v2/services/DeparturesService.scala
@@ -64,7 +64,7 @@ trait DeparturesService {
     ec: ExecutionContext
   ): EitherT[Future, PersistenceError, MovementResponse]
 
-  def getDeparturesForEori(eori: EORINumber)(implicit
+  def getDeparturesForEori(eori: EORINumber, updatedSince: Option[OffsetDateTime])(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
   ): EitherT[Future, PersistenceError, Seq[MovementResponse]]
@@ -134,12 +134,12 @@ class DeparturesServiceImpl @Inject() (persistenceConnector: PersistenceConnecto
         }
     )
 
-  override def getDeparturesForEori(eori: EORINumber)(implicit
+  override def getDeparturesForEori(eori: EORINumber, updatedSince: Option[OffsetDateTime])(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
   ): EitherT[Future, PersistenceError, Seq[MovementResponse]] = EitherT(
     persistenceConnector
-      .getDeparturesForEori(eori)
+      .getDeparturesForEori(eori, updatedSince)
       .map(Right(_))
       .recover {
         case UpstreamErrorResponse(_, NOT_FOUND, _, _) => Left(PersistenceError.DeparturesNotFound(eori))

--- a/it/v2/utils/CommonGenerators.scala
+++ b/it/v2/utils/CommonGenerators.scala
@@ -31,7 +31,9 @@ import v2.models.request.PushNotificationsAssociation
 import v2.models.responses.MovementResponse
 import v2.models.responses.MessageSummary
 
+import java.time.Instant
 import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import scala.math.abs
 
 trait CommonGenerators {
@@ -55,6 +57,14 @@ trait CommonGenerators {
 
   implicit lazy val arbitraryMessageType: Arbitrary[MessageType] =
     Arbitrary(Gen.oneOf(MessageType.values))
+
+  // Restricts the date times to the range of positive long numbers to avoid overflows.
+  implicit lazy val arbitraryOffsetDateTime: Arbitrary[OffsetDateTime] =
+    Arbitrary {
+      for {
+        millis <- Gen.chooseNum(0, Long.MaxValue / 1000L)
+      } yield OffsetDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneOffset.UTC)
+    }
 
   implicit lazy val arbitraryPushNotificationsAssociation: Arbitrary[PushNotificationsAssociation] = Arbitrary {
     for {

--- a/test/v2/controllers/V2ArrivalsControllerSpec.scala
+++ b/test/v2/controllers/V2ArrivalsControllerSpec.scala
@@ -770,7 +770,7 @@ class V2ArrivalsControllerSpec
         arbitraryMovementResponse.arbitrary.sample.value.copy(created = dateTime.plusHours(2), updated = dateTime.plusHours(3))
       )
 
-      when(mockArrivalsPersistenceService.getArrivalsForEori(EORINumber(any()))(any[HeaderCarrier], any[ExecutionContext]))
+      when(mockArrivalsPersistenceService.getArrivalsForEori(EORINumber(any()), any[Option[OffsetDateTime]])(any[HeaderCarrier], any[ExecutionContext]))
         .thenAnswer(
           _ => EitherT.rightT(movementResponses)
         )
@@ -794,7 +794,7 @@ class V2ArrivalsControllerSpec
     "should return arrivals not found if persistence service returns 404" in {
       val eori = EORINumber("ERROR")
 
-      when(mockArrivalsPersistenceService.getArrivalsForEori(EORINumber(any()))(any[HeaderCarrier], any[ExecutionContext]))
+      when(mockArrivalsPersistenceService.getArrivalsForEori(EORINumber(any()), any[Option[OffsetDateTime]])(any[HeaderCarrier], any[ExecutionContext]))
         .thenAnswer(
           _ => EitherT.leftT(PersistenceError.ArrivalsNotFound(eori))
         )
@@ -815,7 +815,7 @@ class V2ArrivalsControllerSpec
     }
 
     "should return unexpected error for all other errors" in {
-      when(mockArrivalsPersistenceService.getArrivalsForEori(EORINumber(any()))(any[HeaderCarrier], any[ExecutionContext]))
+      when(mockArrivalsPersistenceService.getArrivalsForEori(EORINumber(any()), any[Option[OffsetDateTime]])(any[HeaderCarrier], any[ExecutionContext]))
         .thenAnswer(
           _ => EitherT.leftT(PersistenceError.UnexpectedError(None))
         )

--- a/test/v2/controllers/V2DeparturesControllerSpec.scala
+++ b/test/v2/controllers/V2DeparturesControllerSpec.scala
@@ -927,7 +927,7 @@ class V2DeparturesControllerSpec
       )
       val departureResponses = Seq(departureResponse1, departureResponse2)
 
-      when(mockDeparturesPersistenceService.getDeparturesForEori(EORINumber(any()))(any[HeaderCarrier], any[ExecutionContext]))
+      when(mockDeparturesPersistenceService.getDeparturesForEori(EORINumber(any()), any[Option[OffsetDateTime]])(any[HeaderCarrier], any[ExecutionContext]))
         .thenAnswer(
           _ => EitherT.rightT(departureResponses)
         )
@@ -951,7 +951,7 @@ class V2DeparturesControllerSpec
     "should return departure not found if persistence service returns 404" in {
       val eori = EORINumber("ERROR")
 
-      when(mockDeparturesPersistenceService.getDeparturesForEori(EORINumber(any()))(any[HeaderCarrier], any[ExecutionContext]))
+      when(mockDeparturesPersistenceService.getDeparturesForEori(EORINumber(any()), any[Option[OffsetDateTime]])(any[HeaderCarrier], any[ExecutionContext]))
         .thenAnswer(
           _ => EitherT.leftT(PersistenceError.DeparturesNotFound(eori))
         )
@@ -972,7 +972,7 @@ class V2DeparturesControllerSpec
     }
 
     "should return unexpected error for all other errors" in {
-      when(mockDeparturesPersistenceService.getDeparturesForEori(EORINumber(any()))(any[HeaderCarrier], any[ExecutionContext]))
+      when(mockDeparturesPersistenceService.getDeparturesForEori(EORINumber(any()), any[Option[OffsetDateTime]])(any[HeaderCarrier], any[ExecutionContext]))
         .thenAnswer(
           _ => EitherT.leftT(PersistenceError.UnexpectedError(None))
         )

--- a/test/v2/services/ArrivalsServiceSpec.scala
+++ b/test/v2/services/ArrivalsServiceSpec.scala
@@ -155,36 +155,46 @@ class ArrivalsServiceSpec
 
   "Getting a list of Arrivals (Movement) by EORI" - {
 
-    "when an arrival (movement) is found, should return a Right" in forAll(Gen.listOfN(3, arbitrary[MovementResponse]), Gen.option(arbitrary[OffsetDateTime])) {
+    "when an arrival (movement) is found, should return a Right" in forAll(
+      Gen.listOfN(3, arbitrary[MovementResponse]),
+      Gen.option(arbitrary[OffsetDateTime]),
+      arbitrary[EORINumber]
+    ) {
 
-      (expected, updatedSinceMaybe) =>
-        when(mockConnector.getArrivalsForEori(EORINumber("1"), updatedSinceMaybe))
+      (expected, updatedSinceMaybe, eori) =>
+        when(mockConnector.getArrivalsForEori(eori, updatedSinceMaybe))
           .thenReturn(Future.successful(expected))
 
-        val result = sut.getArrivalsForEori(EORINumber("1"), updatedSinceMaybe)
+        val result = sut.getArrivalsForEori(eori, updatedSinceMaybe)
         whenReady(result.value) {
           _ mustBe Right(expected)
         }
     }
 
-    "when an arrival is not found, should return a Left with an ArrivalsNotFound" in forAll(Gen.option(arbitrary[OffsetDateTime])) {
-      updatedSinceMaybe =>
-        when(mockConnector.getArrivalsForEori(EORINumber("1"), updatedSinceMaybe))
+    "when an arrival is not found, should return a Left with an ArrivalsNotFound" in forAll(
+      Gen.option(arbitrary[OffsetDateTime]),
+      arbitrary[EORINumber]
+    ) {
+      (updatedSinceMaybe, eori) =>
+        when(mockConnector.getArrivalsForEori(eori, updatedSinceMaybe))
           .thenReturn(Future.failed(UpstreamErrorResponse("not found", NOT_FOUND)))
 
-        val result = sut.getArrivalsForEori(EORINumber("1"), updatedSinceMaybe)
+        val result = sut.getArrivalsForEori(eori, updatedSinceMaybe)
         whenReady(result.value) {
-          _ mustBe Left(PersistenceError.ArrivalsNotFound(EORINumber("1")))
+          _ mustBe Left(PersistenceError.ArrivalsNotFound(eori))
         }
     }
 
-    "on a failed submission, should return a Left with an UnexpectedError" in forAll(Gen.option(arbitrary[OffsetDateTime])) {
-      updatedSinceMaybe =>
+    "on a failed submission, should return a Left with an UnexpectedError" in forAll(
+      Gen.option(arbitrary[OffsetDateTime]),
+      arbitrary[EORINumber]
+    ) {
+      (updatedSinceMaybe, eori) =>
         val error = UpstreamErrorResponse("error", INTERNAL_SERVER_ERROR)
-        when(mockConnector.getArrivalsForEori(EORINumber("1"), updatedSinceMaybe))
+        when(mockConnector.getArrivalsForEori(eori, updatedSinceMaybe))
           .thenReturn(Future.failed(error))
 
-        val result = sut.getArrivalsForEori(EORINumber("1"), updatedSinceMaybe)
+        val result = sut.getArrivalsForEori(eori, updatedSinceMaybe)
         whenReady(result.value) {
           _ mustBe Left(PersistenceError.UnexpectedError(thr = Some(error)))
         }

--- a/test/v2/services/ArrivalsServiceSpec.scala
+++ b/test/v2/services/ArrivalsServiceSpec.scala
@@ -155,37 +155,39 @@ class ArrivalsServiceSpec
 
   "Getting a list of Arrivals (Movement) by EORI" - {
 
-    "when a arrival (movement) is found, should return a Right" in forAll(Gen.listOfN(3, arbitrary[MovementResponse])) {
+    "when an arrival (movement) is found, should return a Right" in forAll(Gen.listOfN(3, arbitrary[MovementResponse]), Gen.option(arbitrary[OffsetDateTime])) {
 
-      expected =>
-        when(mockConnector.getArrivalsForEori(EORINumber("1")))
+      (expected, updatedSinceMaybe) =>
+        when(mockConnector.getArrivalsForEori(EORINumber("1"), updatedSinceMaybe))
           .thenReturn(Future.successful(expected))
 
-        val result = sut.getArrivalsForEori(EORINumber("1"))
+        val result = sut.getArrivalsForEori(EORINumber("1"), updatedSinceMaybe)
         whenReady(result.value) {
           _ mustBe Right(expected)
         }
     }
 
-    "when a arrival is not found, should return a Left with an ArrivalsNotFound" in {
-      when(mockConnector.getArrivalsForEori(EORINumber("1")))
-        .thenReturn(Future.failed(UpstreamErrorResponse("not found", NOT_FOUND)))
+    "when an arrival is not found, should return a Left with an ArrivalsNotFound" in forAll(Gen.option(arbitrary[OffsetDateTime])) {
+      updatedSinceMaybe =>
+        when(mockConnector.getArrivalsForEori(EORINumber("1"), updatedSinceMaybe))
+          .thenReturn(Future.failed(UpstreamErrorResponse("not found", NOT_FOUND)))
 
-      val result = sut.getArrivalsForEori(EORINumber("1"))
-      whenReady(result.value) {
-        _ mustBe Left(PersistenceError.ArrivalsNotFound(EORINumber("1")))
-      }
+        val result = sut.getArrivalsForEori(EORINumber("1"), updatedSinceMaybe)
+        whenReady(result.value) {
+          _ mustBe Left(PersistenceError.ArrivalsNotFound(EORINumber("1")))
+        }
     }
 
-    "on a failed submission, should return a Left with an UnexpectedError" in {
-      val error = UpstreamErrorResponse("error", INTERNAL_SERVER_ERROR)
-      when(mockConnector.getArrivalsForEori(EORINumber("1")))
-        .thenReturn(Future.failed(error))
+    "on a failed submission, should return a Left with an UnexpectedError" in forAll(Gen.option(arbitrary[OffsetDateTime])) {
+      updatedSinceMaybe =>
+        val error = UpstreamErrorResponse("error", INTERNAL_SERVER_ERROR)
+        when(mockConnector.getArrivalsForEori(EORINumber("1"), updatedSinceMaybe))
+          .thenReturn(Future.failed(error))
 
-      val result = sut.getArrivalsForEori(EORINumber("1"))
-      whenReady(result.value) {
-        _ mustBe Left(PersistenceError.UnexpectedError(thr = Some(error)))
-      }
+        val result = sut.getArrivalsForEori(EORINumber("1"), updatedSinceMaybe)
+        whenReady(result.value) {
+          _ mustBe Left(PersistenceError.UnexpectedError(thr = Some(error)))
+        }
     }
 
   }

--- a/test/v2/services/DeparturesServiceSpec.scala
+++ b/test/v2/services/DeparturesServiceSpec.scala
@@ -287,37 +287,44 @@ class DeparturesServiceSpec
 
     "when a departure (movement) is found, should return a Right" in forAll(
       Gen.listOfN(3, arbitrary[MovementResponse]),
-      Gen.option(arbitrary[OffsetDateTime])
+      Gen.option(arbitrary[OffsetDateTime]),
+      arbitrary[EORINumber]
     ) {
 
-      (expected, updatedSinceMaybe) =>
-        when(mockConnector.getDeparturesForEori(EORINumber("1"), updatedSinceMaybe))
+      (expected, updatedSinceMaybe, eori) =>
+        when(mockConnector.getDeparturesForEori(eori, updatedSinceMaybe))
           .thenReturn(Future.successful(expected))
 
-        val result = sut.getDeparturesForEori(EORINumber("1"), updatedSinceMaybe)
+        val result = sut.getDeparturesForEori(eori, updatedSinceMaybe)
         whenReady(result.value) {
           _ mustBe Right(expected)
         }
     }
 
-    "when a departure is not found, should return a Left with an DepartureNotFound" in forAll(Gen.option(arbitrary[OffsetDateTime])) {
-      updatedSinceMaybe =>
-        when(mockConnector.getDeparturesForEori(EORINumber("1"), updatedSinceMaybe))
+    "when a departure is not found, should return a Left with an DeparturesNotFound" in forAll(
+      Gen.option(arbitrary[OffsetDateTime]),
+      arbitrary[EORINumber]
+    ) {
+      (updatedSinceMaybe, eori) =>
+        when(mockConnector.getDeparturesForEori(eori, updatedSinceMaybe))
           .thenReturn(Future.failed(UpstreamErrorResponse("not found", NOT_FOUND)))
 
-        val result = sut.getDeparturesForEori(EORINumber("1"), updatedSinceMaybe)
+        val result = sut.getDeparturesForEori(eori, updatedSinceMaybe)
         whenReady(result.value) {
-          _ mustBe Left(PersistenceError.DeparturesNotFound(EORINumber("1")))
+          _ mustBe Left(PersistenceError.DeparturesNotFound(eori))
         }
     }
 
-    "on a failed submission, should return a Left with an UnexpectedError" in forAll(Gen.option(arbitrary[OffsetDateTime])) {
-      updatedSinceMaybe =>
+    "on a failed submission, should return a Left with an UnexpectedError" in forAll(
+      Gen.option(arbitrary[OffsetDateTime]),
+      arbitrary[EORINumber]
+    ) {
+      (updatedSinceMaybe, eori) =>
         val error = UpstreamErrorResponse("error", INTERNAL_SERVER_ERROR)
-        when(mockConnector.getDeparturesForEori(EORINumber("1"), updatedSinceMaybe))
+        when(mockConnector.getDeparturesForEori(eori, updatedSinceMaybe))
           .thenReturn(Future.failed(error))
 
-        val result = sut.getDeparturesForEori(EORINumber("1"), updatedSinceMaybe)
+        val result = sut.getDeparturesForEori(eori, updatedSinceMaybe)
         whenReady(result.value) {
           _ mustBe Left(PersistenceError.UnexpectedError(thr = Some(error)))
         }

--- a/test/v2/services/JsonMessageParsingServiceSpec.scala
+++ b/test/v2/services/JsonMessageParsingServiceSpec.scala
@@ -21,7 +21,6 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.libs.json.JsObject
-import play.api.libs.json.JsValue
 import play.api.libs.json.Json
 import uk.gov.hmrc.http.HeaderCarrier
 import v2.base.StreamTestHelpers
@@ -31,7 +30,6 @@ import v2.models.errors.ExtractionError.MessageTypeNotFound
 import v2.models.request.MessageType
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.xml.NodeSeq
 
 class JsonMessageParsingServiceSpec
     extends AnyFreeSpec


### PR DESCRIPTION
This can be merged as all current scenarios will continue to work -- but the `updatedSince` parameter won't work until the respective PR on `transit-movements` is implemeneted.