### PR TITLE
CTCP-1665: Support enhanced error message for incorrect customs offices

### DIFF
--- a/app/v2/controllers/ErrorTranslator.scala
+++ b/app/v2/controllers/ErrorTranslator.scala
@@ -78,9 +78,9 @@ trait ErrorTranslator {
 
     override def convert(routerError: RouterError): PresentationError = routerError match {
       case UnexpectedError(thr) => PresentationError.internalServiceError(cause = thr)
-      case UnrecognisedOffice =>
+      case UnrecognisedOffice(office, field) =>
         PresentationError.badRequestError(
-          "The customs office specified for CustomsOfficeOfDestinationActual or CustomsOfficeOfDeparture must be a customs office located in the United Kingdom"
+          s"The customs office specified for $field must be a customs office located in the United Kingdom ($office was specified)"
         )
     }
   }

--- a/app/v2/models/errors/ErrorCode.scala
+++ b/app/v2/models/errors/ErrorCode.scala
@@ -27,6 +27,7 @@ sealed abstract class ErrorCode(val code: String, val statusCode: Int) extends P
 
 object ErrorCode {
   case object BadRequest           extends ErrorCode("BAD_REQUEST", BAD_REQUEST)
+  case object InvalidOffice        extends ErrorCode("INVALID_OFFICE", BAD_REQUEST)
   case object NotFound             extends ErrorCode("NOT_FOUND", NOT_FOUND)
   case object Forbidden            extends ErrorCode("FORBIDDEN", FORBIDDEN)
   case object InternalServerError  extends ErrorCode("INTERNAL_SERVER_ERROR", INTERNAL_SERVER_ERROR)
@@ -39,6 +40,7 @@ object ErrorCode {
 
   lazy val errorCodes: Seq[ErrorCode] = Seq(
     BadRequest,
+    InvalidOffice,
     NotFound,
     Forbidden,
     InternalServerError,

--- a/app/v2/models/errors/PresentationError.scala
+++ b/app/v2/models/errors/PresentationError.scala
@@ -97,6 +97,8 @@ object PresentationError extends CommonFormats {
         (__ \ CodeFieldName).read[ErrorCode]
     )(StandardError.apply _)
 
+  implicit val invalidOfficeErrorReads: Reads[InvalidOfficeError] = Json.reads[InvalidOfficeError]
+
   implicit val xmlSchemaErrorFormat: OFormat[XmlSchemaValidationError] =
     (
       (__ \ MessageFieldName).format[String] and
@@ -126,6 +128,8 @@ sealed abstract class PresentationError extends Product with Serializable {
 }
 
 case class StandardError(message: String, code: ErrorCode) extends PresentationError
+
+case class InvalidOfficeError(message: String, office: String, field: String, code: ErrorCode) extends PresentationError
 
 case class BindingError(message: String, statusCode: Int, code: ErrorCode) extends PresentationError
 

--- a/app/v2/models/errors/RouterError.scala
+++ b/app/v2/models/errors/RouterError.scala
@@ -19,6 +19,6 @@ package v2.models.errors
 sealed trait RouterError
 
 object RouterError {
-  case object UnrecognisedOffice                            extends RouterError
-  case class UnexpectedError(thr: Option[Throwable] = None) extends RouterError
+  case class UnrecognisedOffice(office: String, field: String) extends RouterError
+  case class UnexpectedError(thr: Option[Throwable] = None)    extends RouterError
 }

--- a/app/v2/services/RouterService.scala
+++ b/app/v2/services/RouterService.scala
@@ -22,17 +22,21 @@ import cats.data.EitherT
 import com.google.inject.ImplementedBy
 import com.google.inject.Inject
 import play.api.http.Status.BAD_REQUEST
+import play.api.libs.json.JsSuccess
+import play.api.libs.json.Json
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.UpstreamErrorResponse
 import v2.connectors.RouterConnector
 import v2.models.EORINumber
 import v2.models.MessageId
 import v2.models.MovementId
+import v2.models.errors.InvalidOfficeError
 import v2.models.errors.RouterError
 import v2.models.request.MessageType
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.util.Try
 import scala.util.control.NonFatal
 
 @ImplementedBy(classOf[RouterServiceImpl])
@@ -58,9 +62,19 @@ class RouterServiceImpl @Inject() (routerConnector: RouterConnector) extends Rou
           _ => Right(())
         )
         .recover {
-          case UpstreamErrorResponse(_, BAD_REQUEST, _, _) => Left(RouterError.UnrecognisedOffice)
+          case UpstreamErrorResponse(message, BAD_REQUEST, _, _) => Left(determineError(message))
           case NonFatal(e) =>
             Left(RouterError.UnexpectedError(thr = Some(e)))
         }
     )
+
+  private def determineError(message: String): RouterError =
+    Try(Json.parse(message))
+      .map(_.validate[InvalidOfficeError])
+      .map {
+        case JsSuccess(value: InvalidOfficeError, _) => RouterError.UnrecognisedOffice(value.office, value.field)
+        case _                                       => RouterError.UnexpectedError()
+      }
+      .getOrElse(RouterError.UnexpectedError()) // we didn't get Json, but the exception here would then be a
+  // red herring, so don't pass it on
 }

--- a/test/v2/controllers/ErrorTranslatorSpec.scala
+++ b/test/v2/controllers/ErrorTranslatorSpec.scala
@@ -197,13 +197,14 @@ class ErrorTranslatorSpec
   }
 
   "Router Error" - {
-    "an UnrecognisedOffice error returns a bad request error" in {
-      val input = RouterError.UnrecognisedOffice
-      val output = PresentationError.badRequestError(
-        "The customs office specified for CustomsOfficeOfDestinationActual or CustomsOfficeOfDeparture must be a customs office located in the United Kingdom"
-      )
+    "an UnrecognisedOffice error returns a bad request error" in forAll(Gen.alphaNumStr, Gen.alphaStr) {
+      (office, field) =>
+        val input = RouterError.UnrecognisedOffice(office, field)
+        val output = PresentationError.badRequestError(
+          s"The customs office specified for $field must be a customs office located in the United Kingdom ($office was specified)"
+        )
 
-      routerErrorConverter.convert(input) mustBe output
+        routerErrorConverter.convert(input) mustBe output
     }
 
     "an Unexpected Error with no exception returns an internal service error with no exception" in {

--- a/test/v2/controllers/V2DeparturesControllerSpec.scala
+++ b/test/v2/controllers/V2DeparturesControllerSpec.scala
@@ -1424,7 +1424,7 @@ class V2DeparturesControllerSpec
       }
 
       "must return BadRequest when router returns BadRequest" in {
-        setup(router = EitherT.leftT(RouterError.UnrecognisedOffice))
+        setup(router = EitherT.leftT(RouterError.UnrecognisedOffice("AB012345", "field")))
 
         val request = fakeJsonAttachRequest()
         val result  = sut.attachMessage(departureId)(request)


### PR DESCRIPTION
Router: https://github.com/hmrc/transit-movements-router/pull/26
Regression tests: https://github.com/hmrc/ctc-traders-api-tests/pull/65