### PR TITLE
Push a SUCCESS notification rather than Hateoas response when a small…

### DIFF
--- a/app/v2/controllers/V2MovementsController.scala
+++ b/app/v2/controllers/V2MovementsController.scala
@@ -533,7 +533,7 @@ class V2MovementsControllerImpl @Inject() (
                  |Upscan Reference: ${reference.value}
                  |Reason: ${failureDetails.failureReason}
                  |Message: ${failureDetails.message}""".stripMargin)
-
+            persistenceService.updateMessage(eori, movementType, movementId, messageId, MessageUpdate(MessageStatus.Failed, None, None))
             pushNotificationsService
               .postPpnsNotification(movementId, messageId, Json.toJson(PresentationError.badRequestError("Uploaded file not accepted.")))
             Future.successful(Ok)
@@ -556,7 +556,13 @@ class V2MovementsControllerImpl @Inject() (
                 _ = pushNotificationsService.postPpnsNotification(
                   movementId,
                   messageId,
-                  Json.toJson(HateoasMovementUpdateResponse(movementId, messageId, movementType, None))
+                  Json.toJson(
+                    Json.obj(
+                      "code" -> "SUCCESS",
+                      "message" ->
+                        s"The message ${messageId.value} for movement ${movementId.value} was successfully processed"
+                    )
+                  )
                 )
               } yield ()
 

--- a/test/v2/controllers/V2MovementsControllerSpec.scala
+++ b/test/v2/controllers/V2MovementsControllerSpec.scala
@@ -6686,7 +6686,6 @@ class V2MovementsControllerSpec
                     eqTo(MessageUpdate(MessageStatus.Success, None, None))
                   )(any[HeaderCarrier], any[ExecutionContext])
 
-                  // Verify that postPpnsNotification was not  called
                   verify(mockPushNotificationService, times(1)).postPpnsNotification(
                     MovementId(eqTo(movementId.value)),
                     MessageId(eqTo(messageId.value)),
@@ -6734,6 +6733,14 @@ class V2MovementsControllerSpec
                 new AcceptHeaderActionProviderImpl()
               )
 
+              val ppnsMessage = Json.toJson(
+                Json.obj(
+                  "code" -> "SUCCESS",
+                  "message" ->
+                    s"The message ${messageId.value} for movement ${movementId.value} was successfully processed"
+                )
+              )
+
               val allowedTypes =
                 if (movementType == MovementType.Arrival) MessageType.messageTypesSentByArrivalTrader else MessageType.messageTypesSentByDepartureTrader
 
@@ -6774,7 +6781,7 @@ class V2MovementsControllerSpec
                 mockPushNotificationService.postPpnsNotification(
                   MovementId(eqTo(movementId.value)),
                   MessageId(eqTo(messageId.value)),
-                  any[JsValue]
+                  eqTo(ppnsMessage)
                 )(
                   any[HeaderCarrier],
                   any[ExecutionContext]
@@ -6846,11 +6853,10 @@ class V2MovementsControllerSpec
                     eqTo(MessageUpdate(MessageStatus.Success, None, None))
                   )(any[HeaderCarrier], any[ExecutionContext])
 
-                  // Verify that postPpnsNotification was not  called
                   verify(mockPushNotificationService, times(1)).postPpnsNotification(
                     MovementId(eqTo(movementId.value)),
                     MessageId(eqTo(messageId.value)),
-                    any[JsValue]
+                    eqTo(ppnsMessage)
                   )(
                     any[HeaderCarrier],
                     any[ExecutionContext]


### PR DESCRIPTION
… message is sent via the large message route (common-transit-convention-traders)