### PR TITLE
CTCP-3475: Add client ID to Upscan callback to enable it to pass through to the stub

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -41,6 +41,7 @@ class AppConfig @Inject() (config: Configuration, servicesConfig: CTCServicesCon
   val pushNotificationsUrl               = Url.parse(servicesConfig.baseUrl("transit-movements-push-notifications"))
   val upscanInitiateUrl                  = Url.parse(servicesConfig.baseUrl("upscan-initiate"))
   val upscanMaximumFileSize              = servicesConfig.config("upscan-initiate").get[Long]("maximumFileSize")
+  val forwardClientIdToUpscan            = servicesConfig.config("upscan-initiate").get[Boolean]("send-client-id")
   val pushNotificationsEnabled           = servicesConfig.config("transit-movements-push-notifications").get[Boolean]("enabled")
 
   lazy val enrolmentKey: String = config.get[String]("security.enrolmentKey")

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -23,5 +23,5 @@ GET        /movements/:movementType/:movementId/messages/:messageId/body        
 
 GET        /movements/push-pull-notifications/box                                   controllers.PushPullNotificationController.getBoxInfo()
 
-POST       /traders/:eori/movements/:movementType/:movementId/messages/:messageId   v2.controllers.V2MovementsController.attachMessageFromUpscan(eori: v2.models.EORINumber, movementType: v2.models.MovementType, movementId: v2.models.MovementId, messageId: v2.models.MessageId)
+POST       /traders/:eori/movements/:movementType/:movementId/messages/:messageId   v2.controllers.V2MovementsController.attachMessageFromUpscan(eori: v2.models.EORINumber, movementType: v2.models.MovementType, movementId: v2.models.MovementId, messageId: v2.models.MessageId, clientId: Option[v2.models.ClientId] ?= None)
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -232,6 +232,7 @@ microservice {
       host = "localhost"
       port = 9570
       maximumFileSize = 20000000  # 20 MB
+      send-client-id = false
     }
 
     common-transit-convention-traders {

--- a/it/v2/utils/CommonGenerators.scala
+++ b/it/v2/utils/CommonGenerators.scala
@@ -174,4 +174,8 @@ trait CommonGenerators {
     Gen.oneOf(MovementType.values)
   }
 
+  implicit lazy val arbitraryClientId: Arbitrary[ClientId] = Arbitrary {
+    Gen.stringOfN(24, Gen.alphaNumChar).map(ClientId.apply)
+  }
+
 }

--- a/test/v2/base/HeaderCarrierMatcher.scala
+++ b/test/v2/base/HeaderCarrierMatcher.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.base
+
+import org.mockito.ArgumentMatcher
+import uk.gov.hmrc.http.HeaderCarrier
+import v2.models.ClientId
+
+object HeaderCarrierMatcher {
+  def apply(comparison: HeaderCarrier => Boolean): ArgumentMatcher[HeaderCarrier] = new HeaderCarrierMatcher(comparison)
+
+  def clientId(expected: ClientId): ArgumentMatcher[HeaderCarrier] = apply(
+    hc => hc.headers(Seq("X-Client-Id")).exists(_._2 == expected.value)
+  )
+}
+
+class HeaderCarrierMatcher(comparison: HeaderCarrier => Boolean) extends ArgumentMatcher[HeaderCarrier] {
+
+  override def matches(argument: HeaderCarrier): Boolean = comparison(argument)
+}

--- a/test/v2/base/TestCommonGenerators.scala
+++ b/test/v2/base/TestCommonGenerators.scala
@@ -21,6 +21,7 @@ import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
 import v2.models.AuditType
 import v2.models.BoxId
+import v2.models.ClientId
 import v2.models.EORINumber
 import v2.models.ItemCount
 import v2.models.LocalReferenceNumber
@@ -232,6 +233,10 @@ trait TestCommonGenerators {
       uri         <- Gen.alphaNumStr
       messageType <- Gen.oneOf(MessageType.values)
     } yield MessageUpdate(status, Some(ObjectStoreURI(uri)), Some(messageType))
+  }
+
+  implicit val arbitraryClientId: Arbitrary[ClientId] = Arbitrary {
+    Gen.stringOfN(24, Gen.alphaNumChar).map(ClientId.apply)
   }
 
 }

--- a/test/v2/fakes/controllers/FakeV2MovementsController.scala
+++ b/test/v2/fakes/controllers/FakeV2MovementsController.scala
@@ -30,6 +30,7 @@ import play.api.mvc.ControllerComponents
 import play.api.test.Helpers.stubControllerComponents
 import v2.controllers.V2MovementsController
 import v2.controllers.stream.StreamingParsers
+import v2.models.ClientId
 import v2.models.EORINumber
 import v2.models.LocalReferenceNumber
 import v2.models.MessageId
@@ -100,7 +101,8 @@ class FakeV2MovementsController @Inject() ()(implicit val materializer: Material
     eoriNumber: EORINumber,
     movementType: MovementType,
     movementId: MovementId,
-    messageId: MessageId
+    messageId: MessageId,
+    clientId: Option[ClientId]
   ): Action[UpscanResponse] =
     Action(parse.json[UpscanResponse]) {
       _ =>

--- a/test/v2/services/UpscanServiceSpec.scala
+++ b/test/v2/services/UpscanServiceSpec.scala
@@ -53,7 +53,6 @@ import scala.annotation.nowarn
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-@nowarn("msg=dead code following this construct")
 class UpscanServiceSpec
     extends AnyFreeSpec
     with Matchers


### PR DESCRIPTION
On External Test, a message sent via Upscan is not getting through to ERMIS as the Upscan callback does not have the client ID. This corrects that by:

* Appending the client ID to the callback URL in the initiate call
* Reading the client ID from the callback method and adding it to the `HeaderCarrier`

Some tests have been modified to test this.