### PR TITLE
Submitted Json messages less than or equals to 5MB should be rejected…

### DIFF
--- a/app/v2/controllers/V2MovementsController.scala
+++ b/app/v2/controllers/V2MovementsController.scala
@@ -155,7 +155,11 @@ class V2MovementsControllerImpl @Inject() (
     if (size <= config.smallMessageSizeLimit) Future.successful(Right(()))
     else {
       Future.successful(
-        Left(PresentationError.entityTooLargeError(s"Your JSON converted XML message size $size must be less than ${config.smallMessageSizeLimit} bytes"))
+        Left(
+          PresentationError.entityTooLargeError(
+            s"Your JSON converted XML message size $size must be less than or equals to ${config.smallMessageSizeLimit} bytes"
+          )
+        )
       )
     }
   }

--- a/app/v2/controllers/V2MovementsController.scala
+++ b/app/v2/controllers/V2MovementsController.scala
@@ -151,6 +151,15 @@ class V2MovementsControllerImpl @Inject() (
     }
   }
 
+  private def convertedSizeIsLessThanLimit(size: Long): EitherT[Future, PresentationError, Unit] = EitherT {
+    if (size <= config.smallMessageSizeLimit) Future.successful(Right(()))
+    else {
+      Future.successful(
+        Left(PresentationError.entityTooLargeError(s"Your JSON converted XML message size $size must be less than ${config.smallMessageSizeLimit} bytes"))
+      )
+    }
+  }
+
   def createMovement(movementType: MovementType): Action[Source[ByteString, _]] =
     movementType match {
       case MovementType.Arrival =>
@@ -584,9 +593,10 @@ class V2MovementsControllerImpl @Inject() (
       hc: HeaderCarrier,
       request: AuthenticatedRequest[Source[ByteString, _]]
     ): EitherT[Future, PresentationError, UpdateMovementResponse] =
-      withReusableSource(src) {
-        source =>
+      withReusableSourceAndSize(src) {
+        (source, size) =>
           for {
+            _              <- convertedSizeIsLessThanLimit(size)
             _              <- validationService.validateXml(messageType, source).asPresentation(jsonToXmlValidationErrorConverter, materializerExecutionContext)
             updateResponse <- updateAndSendToEIS(movementId, movementType, messageType, source)
           } yield updateResponse
@@ -755,9 +765,10 @@ class V2MovementsControllerImpl @Inject() (
     movementType: MovementType,
     messageType: MessageType
   )(implicit hc: HeaderCarrier, request: AuthenticatedRequest[Source[ByteString, _]]) =
-    withReusableSource(src) {
-      source =>
+    withReusableSourceAndSize(src) {
+      (source, size) =>
         for {
+          _      <- convertedSizeIsLessThanLimit(size)
           _      <- validationService.validateXml(messageType, source).asPresentation(jsonToXmlValidationErrorConverter, materializerExecutionContext)
           result <- persistAndSendToEIS(source, movementType, messageType)
         } yield result

--- a/app/v2/utils/StreamWithFile.scala
+++ b/app/v2/utils/StreamWithFile.scala
@@ -27,10 +27,12 @@ import play.api.Logging
 import play.api.libs.Files.TemporaryFileCreator
 import v2.models.errors.PresentationError
 
+import java.nio.file.Files
 import java.nio.file.Path
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.util.control.NonFatal
+import scala.util.Try
 
 trait StreamWithFile {
   self: Logging =>
@@ -39,11 +41,21 @@ trait StreamWithFile {
     src: Source[ByteString, _]
   )(
     block: Source[ByteString, _] => EitherT[Future, PresentationError, R]
+  )(implicit temporaryFileCreator: TemporaryFileCreator, mat: Materializer, ec: ExecutionContext): EitherT[Future, PresentationError, R] =
+    withReusableSourceAndSize(src)(
+      (fileSource, _) => block(fileSource)
+    )
+
+  def withReusableSourceAndSize[R](
+    src: Source[ByteString, _]
+  )(
+    block: (Source[ByteString, _], Long) => EitherT[Future, PresentationError, R]
   )(implicit temporaryFileCreator: TemporaryFileCreator, mat: Materializer, ec: ExecutionContext): EitherT[Future, PresentationError, R] = {
     val file = temporaryFileCreator.create()
     (for {
       _      <- writeToFile(file, src)
-      result <- block(FileIO.fromPath(file))
+      size   <- calculateSize(file)
+      result <- block(FileIO.fromPath(file), size)
     } yield result)
       .flatTap {
         _ =>
@@ -52,6 +64,17 @@ trait StreamWithFile {
       }
 
   }
+
+  private def calculateSize(file: Path): EitherT[Future, PresentationError, Long] =
+    EitherT(
+      Future.fromTry(
+        Try(Files.size(file))
+          .map(Right.apply)
+          .recover {
+            case NonFatal(e) => Left(PresentationError.internalServiceError(cause = Some(e)))
+          }
+      )
+    )
 
   private def writeToFile(file: Path, src: Source[ByteString, _])(implicit
     mat: Materializer,

--- a/test/v2/controllers/V2MovementsControllerSpec.scala
+++ b/test/v2/controllers/V2MovementsControllerSpec.scala
@@ -1060,7 +1060,7 @@ class V2MovementsControllerSpec
           status(result) mustBe REQUEST_ENTITY_TOO_LARGE
           contentAsJson(result) mustBe Json.obj(
             "code"    -> "REQUEST_ENTITY_TOO_LARGE",
-            "message" -> "Your JSON converted XML message size 58 must be less than 40 bytes"
+            "message" -> "Your JSON converted XML message size 58 must be less than or equals to 40 bytes"
           )
           verify(mockConversionService, times(1)).jsonToXml(eqTo(MessageType.DeclarationData), any())(any(), any(), any())
           verify(mockValidationService, times(1)).validateJson(eqTo(MessageType.DeclarationData), any())(any(), any())
@@ -2612,7 +2612,7 @@ class V2MovementsControllerSpec
 
           contentAsJson(result) mustBe Json.obj(
             "code"    -> "REQUEST_ENTITY_TOO_LARGE",
-            "message" -> "Your JSON converted XML message size 58 must be less than 40 bytes"
+            "message" -> "Your JSON converted XML message size 58 must be less than or equals to 40 bytes"
           )
           verify(mockConversionService, times(1)).jsonToXml(eqTo(MessageType.ArrivalNotification), any())(any(), any(), any())
           verify(mockValidationService, times(1)).validateJson(eqTo(MessageType.ArrivalNotification), any())(any(), any())

--- a/test/v2/controllers/V2MovementsControllerSpec.scala
+++ b/test/v2/controllers/V2MovementsControllerSpec.scala
@@ -1006,6 +1006,68 @@ class V2MovementsControllerSpec
           verify(mockPushNotificationService, times(1)).associate(MovementId(anyString()), eqTo(MovementType.Departure), any())(any(), any())
       }
 
+      "must return Payload Too Large when converted JSON in XML is greater in limit" in forAll(
+        arbitraryMovementResponse().arbitrary,
+        arbitraryBoxResponse.arbitrary
+      ) {
+        (movementResponse, boxResponse) =>
+          val ControllerAndMocks(
+            sut,
+            mockValidationService,
+            mockPersistenceService,
+            mockRouterService,
+            mockAuditService,
+            mockConversionService,
+            _,
+            _,
+            mockPushNotificationService,
+            _,
+            mockAppConfig
+          ) = createControllerAndMocks()
+
+          when(
+            mockValidationService
+              .validateXml(eqTo(MessageType.DeclarationData), any[Source[ByteString, _]]())(any[HeaderCarrier], any[ExecutionContext])
+          ).thenAnswer {
+            _ =>
+              EitherT.rightT(())
+          }
+
+          when(
+            mockValidationService
+              .validateJson(eqTo(MessageType.DeclarationData), any[Source[ByteString, _]]())(any[HeaderCarrier], any[ExecutionContext])
+          ).thenAnswer {
+            invocation =>
+              jsonValidationMockAnswer(MovementType.Departure)(invocation)
+          }
+          when(mockAuditService.audit(any(), any(), eqTo(MimeTypes.JSON), any[Long]())(any(), any())).thenReturn(Future.successful(()))
+
+          when(
+            mockConversionService
+              .jsonToXml(eqTo(MessageType.DeclarationData), any[Source[ByteString, _]]())(
+                any[HeaderCarrier],
+                any[ExecutionContext],
+                any[Materializer]
+              )
+          ).thenReturn {
+            val source = singleUseStringSource(CC015C.mkString)
+            EitherT.rightT[Future, ConversionError](source)
+          }
+          when(mockAppConfig.smallMessageSizeLimit).thenReturn(40)
+
+          val request = fakeCreateMovementRequest("POST", standardHeaders, singleUseStringSource(CC015Cjson), MovementType.Departure)
+          val result  = sut.createMovement(MovementType.Departure)(request)
+          status(result) mustBe REQUEST_ENTITY_TOO_LARGE
+          contentAsJson(result) mustBe Json.obj(
+            "code"    -> "REQUEST_ENTITY_TOO_LARGE",
+            "message" -> "Your JSON converted XML message size 58 must be less than 40 bytes"
+          )
+          verify(mockConversionService, times(1)).jsonToXml(eqTo(MessageType.DeclarationData), any())(any(), any(), any())
+          verify(mockValidationService, times(1)).validateJson(eqTo(MessageType.DeclarationData), any())(any(), any())
+          verify(mockAuditService, times(1)).audit(eqTo(AuditType.DeclarationData), any(), eqTo(MimeTypes.JSON), any[Long]())(any(), any())
+
+      }
+
       "must return Accepted if the Push Notification Service reports an error" in forAll(
         arbitraryMovementResponse().arbitrary
       ) {
@@ -2501,6 +2563,60 @@ class V2MovementsControllerSpec
             any[HeaderCarrier],
             any[ExecutionContext]
           )
+      }
+
+      "must return Payload Too Large when converted JSON in XML is greater in limit" in forAll(
+        arbitraryMovementResponse().arbitrary,
+        arbitraryBoxResponse.arbitrary
+      ) {
+        (movementResponse, boxResponse) =>
+          val ControllerAndMocks(
+            sut,
+            mockValidationService,
+            mockPersistenceService,
+            mockRouterService,
+            mockAuditService,
+            mockConversionService,
+            _,
+            _,
+            mockPushNotificationService,
+            _,
+            mockAppConfig
+          ) = createControllerAndMocks()
+
+          when(
+            mockValidationService
+              .validateJson(eqTo(MessageType.ArrivalNotification), any[Source[ByteString, _]]())(any[HeaderCarrier], any[ExecutionContext])
+          ).thenAnswer {
+            invocation =>
+              jsonValidationMockAnswer(MovementType.Arrival)(invocation)
+          }
+          when(mockAuditService.audit(any(), any(), eqTo(MimeTypes.JSON), any[Long]())(any(), any())).thenReturn(Future.successful(()))
+
+          when(
+            mockConversionService
+              .jsonToXml(eqTo(MessageType.ArrivalNotification), any[Source[ByteString, _]]())(
+                any[HeaderCarrier],
+                any[ExecutionContext],
+                any[Materializer]
+              )
+          ).thenReturn {
+            val source = singleUseStringSource(CC007C.mkString)
+            EitherT.rightT[Future, ConversionError](source)
+          }
+          when(mockAppConfig.smallMessageSizeLimit).thenReturn(40)
+
+          val request = fakeCreateMovementRequest("POST", standardHeaders, singleUseStringSource(CC007Cjson), MovementType.Arrival)
+          val result  = sut.createMovement(MovementType.Arrival)(request)
+          status(result) mustBe REQUEST_ENTITY_TOO_LARGE
+
+          contentAsJson(result) mustBe Json.obj(
+            "code"    -> "REQUEST_ENTITY_TOO_LARGE",
+            "message" -> "Your JSON converted XML message size 58 must be less than 40 bytes"
+          )
+          verify(mockConversionService, times(1)).jsonToXml(eqTo(MessageType.ArrivalNotification), any())(any(), any(), any())
+          verify(mockValidationService, times(1)).validateJson(eqTo(MessageType.ArrivalNotification), any())(any(), any())
+          verify(mockAuditService, times(1)).audit(eqTo(AuditType.ArrivalNotification), any(), eqTo(MimeTypes.JSON), any[Long]())(any(), any())
       }
 
       "must return Accepted if the Push Notification Service reports an error" in forAll(
@@ -5472,6 +5588,28 @@ class V2MovementsControllerSpec
             any[HeaderCarrier],
             any[ExecutionContext]
           )
+        }
+
+        "must return Payload Too Large when JSON converted XML is not in limit" in {
+          val ControllerAndMocks(
+            sut,
+            mockValidationService,
+            mockPersistenceService,
+            mockRouterService,
+            mockAuditService,
+            mockConversionService,
+            _,
+            _,
+            _,
+            _,
+            mockAppConfig
+          ) = setup()
+          when(mockAppConfig.smallMessageSizeLimit).thenReturn(26)
+          val request = fakeJsonAttachRequest(contentJson)
+          val result  = sut.attachMessage(movementType, movementId)(request)
+
+          status(result) mustBe REQUEST_ENTITY_TOO_LARGE
+
         }
 
         "must return Bad Request when unable to find a IE141 message type " in forAll(


### PR DESCRIPTION
… if the converted XML is over 5MB(common-transit-convention-traders)