### PR TITLE
CTCP-3894: Add large message upload responses to examples in definition

### DIFF
--- a/resources/public/api/conf/2.0/application.yaml
+++ b/resources/public/api/conf/2.0/application.yaml
@@ -54,31 +54,9 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/CustomsTransitsMovementsDeparturesResponse'
-                  - description: JSON payload
-                    example:
-                      _links:
-                        self:
-                          href: /customs/transits/movements/departures/62fb8f33d233578e
-                        messages:
-                          href: /customs/transits/movements/departures/62fb8f33d233578e/messages
-                        message:
-                          href: /customs/transits/movements/departures/62fb8f33d233578e/messages/64e760870c18a87a
-                      departureId: 62fb8f33d233578e
-                      messageId: 64e760870c18a87a
-                      boxId: b54c2424-955b-496c-bbce-dfb9f57cd797
-              example:
-                _links:
-                  self:
-                    href: /customs/transits/movements/departures/62fb8f33d233578e
-                  messages:
-                    href: /customs/transits/movements/departures/62fb8f33d233578e/messages
-                  message:
-                    href: /customs/transits/movements/departures/62fb8f33d233578e/messages/64e760870c18a87a
-                departureId: 62fb8f33d233578e
-                messageId: 64e760870c18a87a
-                boxId: b54c2424-955b-496c-bbce-dfb9f57cd797
+                oneOf:
+                  - $ref: '#/components/schemas/SmallMessageNewDepartureResponse'
+                  - $ref: '#/components/schemas/LargeMessageNewDepartureResponse'
         '400':
           description: Bad Request
           content:
@@ -488,15 +466,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CustomsTransitsMovementsDeparturesMessagesResponse1'
-              example:
-                _links:
-                  self:
-                    href: /customs/transits/movements/departures/6365135ba5e821ee/messages/634982098f02f00a
-                  departure:
-                    href: /customs/transits/movements/departures/6365135ba5e821ee
-                departureId: 6365135ba5e821ee
-                messageId: 634982098f02f00a
+                oneOf:
+                  - $ref: '#/components/schemas/SmallMessageDepartureMessagesResponse'
+                  - $ref: '#/components/schemas/LargeMessageDepartureMessagesResponse'
         '400':
           description: Bad Request
           content:
@@ -769,18 +741,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CustomsTransitsMovementsArrivalsResponse'
-              example:
-                _links:
-                  self:
-                    href: /customs/transits/movements/arrivals/62fb8f33d233578e
-                  messages:
-                    href: /customs/transits/movements/arrivals/62fb8f33d233578e/messages
-                  message:
-                    href: /customs/transits/movements/arrivals/62fb8f33d233578e/messages/64e760870c18a87a
-                arrivalId: 62fb8f33d233578e
-                messageId: 64e760870c18a87a
-                boxId: b54c2424-955b-496c-bbce-dfb9f57cd797
+                oneOf:
+                  - $ref: '#/components/schemas/SmallMessageNewArrivalResponse'
+                  - $ref: '#/components/schemas/LargeMessageNewArrivalResponse'
         '400':
           description: Schema Validation
           content:
@@ -1167,15 +1130,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CustomsTransitsMovementsArrivalsMessagesResponse1'
-              example:
-                _links:
-                  self:
-                    href: /customs/transits/movements/arrivals/6365135ba5e821ee/messages/634982098f02f00a
-                  arrival:
-                    href: /customs/transits/movements/arrivals/6365135ba5e821ee
-                arrivalId: 6365135ba5e821ee
-                messageId: 634982098f02f00a
+                oneOf:
+                  - $ref: '#/components/schemas/SmallMessageArrivalMessageResponse'
+                  - $ref: '#/components/schemas/LargeMessageArrivalMessageResponse'
         '400':
           description: Bad Request
           content:
@@ -1541,20 +1498,58 @@ components:
             received: 2022-11-10T15:32:51.459Z
             type: IE007
             status: Success
-    CustomsTransitsMovementsArrivalsMessagesResponse1:
-      title: CustomsTransitsMovementsArrivalsMessagesResponse1
+    SmallMessageArrivalMessageResponse:
+      title: Small message submission response
       required:
         - _links
+        - arrivalId
+        - messageId
       type: object
       properties:
         _links:
           $ref: '#/components/schemas/Links10'
+        arrivalId:
+          type: string
+        messageId:
+          type: string
       example:
         _links:
           self:
             href: /customs/transits/movements/arrivals/6365135ba5e821ee/messages/634982098f02f00a
           arrival:
             href: /customs/transits/movements/arrivals/6365135ba5e821ee
+        arrivalId: 6365135ba5e821ee
+        messageId: 634982098f02f00a
+    LargeMessageArrivalMessageResponse:
+      title: Large message (empty payload) response
+      required:
+        - _links
+        - arrivalId
+        - messageId
+        - uploadDetails
+      type: object
+      properties:
+        _links:
+          $ref: '#/components/schemas/Links10'
+        arrivalId:
+          type: string
+        messageId:
+          type: string
+        uploadDetails:
+          $ref: '#/components/schemas/UploadDetails'
+      example:
+        _links:
+          self:
+            href: /customs/transits/movements/arrivals/6365135ba5e821ee/messages/634982098f02f00a
+          arrival:
+            href: /customs/transits/movements/arrivals/6365135ba5e821ee
+        arrivalId: 6365135ba5e821ee
+        messageId: 634982098f02f00a
+        uploadDetails:
+          href: 'https://hmrc.gov.uk/upscan/upscan-proxy'
+          fields:
+            field_a: 'value a'
+            field_b: 'value b'
     CustomsTransitsMovementsArrivalsMessagesResponse2:
       title: CustomsTransitsMovementsArrivalsMessagesResponse2
       required:
@@ -1591,14 +1586,20 @@ components:
         type: IE007
         status: Success
         body: <ncts:CC007C PhaseID="NCTS5.0" xmlns:ncts="http://ncts.dgtaxud.ec">...</ncts:CC007C>
-    CustomsTransitsMovementsArrivalsResponse:
-      title: CustomsTransitsMovementsArrivalsResponse
+    SmallMessageNewArrivalResponse:
+      title: Small message submission response
       required:
         - _links
+        - arrivalId
+        - messageId
       type: object
       properties:
         _links:
           $ref: '#/components/schemas/Links'
+        arrivalId:
+          type: string
+        messageId:
+          type: string
         boxId:
           type: string
       example:
@@ -1607,7 +1608,46 @@ components:
             href: /customs/transits/movements/arrivals/62fb8f33d233578e
           messages:
             href: /customs/transits/movements/arrivals/62fb8f33d233578e/messages
+          message:
+            href: /customs/transits/movements/arrivals/62fb8f33d233578e/messages/64e760870c18a87a
+        arrivalId: 62fb8f33d233578e
+        messageId: 64e760870c18a87a
         boxId: b54c2424-955b-496c-bbce-dfb9f57cd797
+    LargeMessageNewArrivalResponse:
+      title: Large message (empty payload) submission response
+      required:
+        - _links
+        - arrivalId
+        - messageId
+        - uploadDetails
+      type: object
+      properties:
+        _links:
+          $ref: '#/components/schemas/Links'
+        arrivalId:
+          type: string
+        messageId:
+          type: string
+        boxId:
+          type: string
+        upoloadDetails:
+          $ref: '#/components/schemas/UploadDetails'
+      example:
+        _links:
+          self:
+            href: /customs/transits/movements/arrivals/62fb8f33d233578e
+          messages:
+            href: /customs/transits/movements/arrivals/62fb8f33d233578e/messages
+          message:
+            href: /customs/transits/movements/arrivals/62fb8f33d233578e/messages/64e760870c18a87a
+        arrivalId: 62fb8f33d233578e
+        messageId: 64e760870c18a87a
+        boxId: b54c2424-955b-496c-bbce-dfb9f57cd797
+        uploadDetails:
+          href: 'https://hmrc.gov.uk/upscan/upscan-proxy'
+          fields:
+            field_a: 'value a'
+            field_b: 'value b'
     CustomsTransitsMovementsArrivalsResponse1:
       title: CustomsTransitsMovementsArrivalsResponse1
       required:
@@ -1723,20 +1763,58 @@ components:
             received: 2022-11-10T15:32:51.459Z
             type: IE015
             status: Success
-    CustomsTransitsMovementsDeparturesMessagesResponse1:
-      title: CustomsTransitsMovementsDeparturesMessagesResponse1
+    SmallMessageDepartureMessagesResponse:
+      title: Small message submission response
       required:
         - _links
+        - departureId
+        - messageId
       type: object
       properties:
         _links:
           $ref: '#/components/schemas/Links2'
+        departureId:
+          type: string
+        messageId:
+          type: string
       example:
         _links:
           self:
             href: /customs/transits/movements/departures/6365135ba5e821ee/messages/634982098f02f00a
           departure:
             href: /customs/transits/movements/departures/6365135ba5e821ee
+        departureId: 6365135ba5e821ee
+        messageId: 634982098f02f00a
+    LargeMessageDepartureMessagesResponse:
+      title: Large message (empty payload) response
+      required:
+        - _links
+        - departureId
+        - messageId
+        - uploadDetails
+      type: object
+      properties:
+        _links:
+          $ref: '#/components/schemas/Links2'
+        departureId:
+          type: string
+        messageId:
+          type: string
+        uploadDetails:
+          $ref: '#/components/schemas/UploadDetails'
+      example:
+        _links:
+          self:
+            href: /customs/transits/movements/departures/6365135ba5e821ee/messages/634982098f02f00a
+          departure:
+            href: /customs/transits/movements/departures/6365135ba5e821ee
+        departureId: 6365135ba5e821ee
+        messageId: 634982098f02f00a
+        uploadDetails:
+          href: "https://hmrc.gov.uk/upload/upload-proxy"
+          fields:
+            field_a: 'value a'
+            field_b: 'value b'
     CustomsTransitsMovementsDeparturesMessagesResponse2:
       title: CustomsTransitsMovementsDeparturesMessagesResponse2
       required:
@@ -1783,14 +1861,20 @@ components:
       type: string
       example:
         <ncts:CC007C PhaseID="NCTS5.0" xmlns:ncts="http://ncts.dgtaxud.ec">...</ncts:CC007C>
-    CustomsTransitsMovementsDeparturesResponse:
-      title: CustomsTransitsMovementsDeparturesResponse
+    SmallMessageNewDepartureResponse:
+      title: Small message submission response
       required:
         - _links
+        - departureId
+        - messageId
       type: object
       properties:
         _links:
           $ref: '#/components/schemas/Links'
+        departureId:
+          type: string
+        messageId:
+          type: string
         boxId:
           type: string
       example:
@@ -1799,7 +1883,62 @@ components:
             href: /customs/transits/movements/departures/62fb8f33d233578e
           messages:
             href: /customs/transits/movements/departures/62fb8f33d233578e/messages
+          message:
+            href: /customs/transits/movements/departures/62fb8f33d233578e/messages/64fed8accac1fdc4
+        departureId: 62fb8f33d233578e
+        messageId: 64fed8accac1fdc4
         boxId: b54c2424-955b-496c-bbce-dfb9f57cd797
+    UploadDetails:
+      title: Upload Details
+      required: [href, fields]
+      type: object
+      additionalProperties: false
+      properties:
+        href:
+          type: string
+        fields:
+          type: object
+          additionalProperties: true
+      example:
+        href: 'https://hmrc.gov.uk/upscan/upload-proxy'
+        fields:
+          field_a: 'value a'
+          field_b: 'value b'
+    LargeMessageNewDepartureResponse:
+      title: Large message (empty payload) response
+      required:
+        - _links
+        - departureId
+        - messageId
+        - uploadDetails
+      type: object
+      properties:
+        _links:
+          $ref: '#/components/schemas/Links'
+        departureId:
+          type: string
+        messageId:
+          type: string
+        boxId:
+          type: string
+        uploadRequest:
+          $ref: '#/components/schemas/UploadDetails'
+      example:
+        _links:
+          self:
+            href: /customs/transits/movements/departures/62fb8f33d233578e
+          messages:
+            href: /customs/transits/movements/departures/62fb8f33d233578e/messages
+          message:
+            href: /customs/transits/movements/departures/62fb8f33d233578e/messages/64fed8accac1fdc4
+        boxId: b54c2424-955b-496c-bbce-dfb9f57cd797
+        departureId: 62fb8f33d233578e
+        messageId: 64fed8accac1fdc4
+        uploadDetails:
+          href: 'https://hmrc.gov.uk/upscan/upload-proxy'
+          fields:
+            field_a: 'value a'
+            field_b: 'value b'
     CustomsTransitsMovementsDeparturesResponse1:
       title: CustomsTransitsMovementsDeparturesResponse1
       required:


### PR DESCRIPTION
There weren't any examples of the large message upload responses on the definition -- this corrects that. This adds drop downs to the examples to the right that allows small/large responses to be seen, e.g.:

![image](https://github.com/hmrc/common-transit-convention-traders/assets/93977310/c0e512fc-e9ba-48fd-8089-ac706458414f)

and in the response definitions in the main body: e.g.

![image](https://github.com/hmrc/common-transit-convention-traders/assets/93977310/d5356a6b-b7c5-4d58-95fc-11a98de3998c)
