### PR TITLE
Add clientId in common-transit-convention-traders and pass to persistence service

### DIFF
--- a/app/v2/connectors/PersistenceConnector.scala
+++ b/app/v2/connectors/PersistenceConnector.scala
@@ -160,6 +160,7 @@ class PersistenceConnectorImpl @Inject() (httpClientV2: HttpClientV2, val metric
         val httpClient = httpClientV2
           .post(url"$url")
           .withInternalAuthToken
+          .withClientId
 
         (source match {
           case Some(src) => httpClient.setHeader(HeaderNames.CONTENT_TYPE -> MimeTypes.XML).withBody(src)


### PR DESCRIPTION
Pass Optional clientId to transit-movements as part of Header for createDeparture and createArrival request. So that we can save clientId in transit-movements database.
Note:- for web clientId is optional and for API it is mandatory.