### PR TITLE
Added v2.1 routing to getMessageBody

### DIFF
--- a/app/routing/GenericRouting.scala
+++ b/app/routing/GenericRouting.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package routing
+
+import com.google.inject.Inject
+import controllers.common.stream.StreamingParsers
+import models.common.MessageId
+import models.common.MovementId
+import models.common.MovementType
+import models.common.errors.PresentationError
+import org.apache.pekko.stream.Materializer
+import play.api.Logging
+import play.api.libs.json.Json
+import play.api.mvc._
+import play.mvc.Http.HeaderNames
+import v2.controllers.{V2MovementsController => V2TransitionalMovementsController}
+import v2_1.controllers.V2MovementsController
+
+import scala.concurrent.Future
+
+class GenericRouting @Inject() (
+  val controllerComponents: ControllerComponents,
+  v2TransitionalMovements: V2TransitionalMovementsController,
+  v2Movements: V2MovementsController
+)(implicit
+  val materializer: Materializer
+) extends BaseController
+    with StreamingParsers
+    with VersionedRouting
+    with Logging {
+
+  private lazy val validHeaders: Seq[String] = Seq(
+    VERSION_2_ACCEPT_HEADER_VALUE_JSON.value,
+    VERSION_2_ACCEPT_HEADER_VALUE_XML.value,
+    VERSION_2_1_ACCEPT_HEADER_VALUE_JSON.value,
+    VERSION_2_1_ACCEPT_HEADER_VALUE_XML.value
+  )
+
+  private def checkAcceptHeader(implicit request: Request[_]): Option[VersionedAcceptHeader] = {
+    val requestHeaderValue = request.headers.get(HeaderNames.ACCEPT)
+    requestHeaderValue.flatMap {
+      acceptHeaderValue =>
+        VersionedRouting.formatAccept(acceptHeaderValue) match {
+          case Right(validatedAcceptHeader) if validHeaders.contains(validatedAcceptHeader.value) => Some(validatedAcceptHeader)
+          case _                                                                                  => None
+        }
+    }
+  }
+
+  def getMessageBody(movementType: MovementType, movementId: MovementId, messageId: MessageId): Action[AnyContent] =
+    Action.async {
+      implicit request =>
+        checkAcceptHeader match {
+          case Some(VERSION_2_ACCEPT_HEADER_VALUE_JSON) | Some(VERSION_2_ACCEPT_HEADER_VALUE_XML) =>
+            v2TransitionalMovements.getMessageBody(movementType, movementId, messageId)(request)
+          case Some(VERSION_2_1_ACCEPT_HEADER_VALUE_JSON) | Some(VERSION_2_1_ACCEPT_HEADER_VALUE_XML) =>
+            v2Movements.getMessageBody(movementType, movementId, messageId)(request)
+          case _ => Future.successful(NotAcceptable(Json.toJson(PresentationError.notAcceptableError("The Accept header is missing or invalid."))))
+        }
+    }
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -19,7 +19,7 @@ GET        /movements/departures/:departureId/messages                          
 
 GET        /movements/departures/:departureId/messages/:messageId                   routing.DeparturesRouter.getMessage(departureId: String, messageId: String)
 
-GET        /movements/:movementType/:movementId/messages/:messageId/body            v2.controllers.V2MovementsController.getMessageBody(movementType: MovementType, movementId: MovementId, messageId: models.common.MessageId)
+GET        /movements/:movementType/:movementId/messages/:messageId/body            routing.GenericRouting.getMessageBody(movementType: MovementType, movementId: MovementId, messageId: models.common.MessageId)
 
 GET        /movements/push-pull-notifications/box                                   controllers.PushPullNotificationController.getBoxInfo()
 

--- a/test/routing/GenericRoutingSpec.scala
+++ b/test/routing/GenericRoutingSpec.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package routing
+
+import cats.implicits.catsSyntaxOptionId
+import cats.implicits.none
+import models.common.MessageId
+import models.common.MovementId
+import models.common.MovementType
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.http.HeaderNames
+import play.api.http.Status.NOT_ACCEPTABLE
+import play.api.http.Status.OK
+import play.api.libs.json.Json
+import play.api.test.Helpers.contentAsJson
+import play.api.test.Helpers.defaultAwaitTimeout
+import play.api.test.Helpers.status
+import play.api.test.Helpers.stubControllerComponents
+import play.api.test.FakeHeaders
+import play.api.test.FakeRequest
+import v2.base.TestActorSystem
+import v2_1.fakes.controllers.FakeV2MovementsController
+import v2_1.fakes.controllers.FakeV2TransitionalMovementsController
+
+class GenericRoutingSpec extends AnyWordSpec with Matchers with TestActorSystem with ScalaFutures {
+
+  ".getMessageBody" should {
+
+    "Route to transitional controller (v2) when the accept header is 'application/vnd.hmrc.2.0+json'" in new Setup {
+      val result = controller.getMessageBody(movementType, movementId, messageId)(createFakeRequest("application/vnd.hmrc.2.0+json".some))
+      status(result) shouldBe OK
+      contentAsJson(result) shouldBe Json.obj("version" -> 2)
+    }
+
+    "Route to transitional controller (v2) when the accept header is 'application/vnd.hmrc.2.0+xml'" in new Setup {
+      val result = controller.getMessageBody(movementType, movementId, messageId)(createFakeRequest("application/vnd.hmrc.2.0+xml".some))
+      status(result) shouldBe OK
+      contentAsJson(result) shouldBe Json.obj("version" -> 2)
+    }
+
+    "Route to transitional controller (v2.1) when the accept header is 'application/vnd.hmrc.2.1+json'" in new Setup {
+      val result = controller.getMessageBody(movementType, movementId, messageId)(createFakeRequest("application/vnd.hmrc.2.1+json".some))
+      status(result) shouldBe OK
+      contentAsJson(result) shouldBe Json.obj("version" -> 2.1)
+    }
+
+    "Route to transitional controller (v2.1) when the accept header is 'application/vnd.hmrc.2.1+xml'" in new Setup {
+      val result = controller.getMessageBody(movementType, movementId, messageId)(createFakeRequest("application/vnd.hmrc.2.1+xml".some))
+      status(result) shouldBe OK
+      contentAsJson(result) shouldBe Json.obj("version" -> 2.1)
+    }
+
+    "Return NotAccepted when the ACCEPT header is missing" in new Setup {
+      val result = controller.getMessageBody(movementType, movementId, messageId)(createFakeRequest(none))
+      status(result) shouldBe NOT_ACCEPTABLE
+      contentAsJson(result) shouldBe Json.obj("message" -> "The Accept header is missing or invalid.", "code" -> "NOT_ACCEPTABLE")
+
+    }
+
+    "Return NotAccepted when the ACCEPT header value does not match the required headers" in new Setup {
+      val result = controller.getMessageBody(movementType, movementId, messageId)(createFakeRequest("invalid-accept-header".some))
+      status(result) shouldBe NOT_ACCEPTABLE
+      contentAsJson(result) shouldBe Json.obj("message" -> "The Accept header is missing or invalid.", "code" -> "NOT_ACCEPTABLE")
+    }
+  }
+
+  trait Setup {
+
+    val controller = new GenericRouting(
+      stubControllerComponents(),
+      new FakeV2TransitionalMovementsController(),
+      new FakeV2MovementsController()
+    )
+
+    val movementType: MovementType = MovementType.Arrival
+    val movementId: MovementId     = MovementId("someId")
+    val messageId: MessageId       = MessageId("someMessageId")
+
+    def createFakeRequest(headerValue: Option[String]) =
+      FakeRequest(
+        method = "",
+        uri = "",
+        body = <test></test>,
+        headers = FakeHeaders(
+          headerValue
+            .map(
+              hv => Seq(HeaderNames.ACCEPT -> hv)
+            )
+            .getOrElse(Seq.empty)
+        )
+      )
+  }
+}

--- a/test/v2/controllers/V2MovementsControllerSpec.scala
+++ b/test/v2/controllers/V2MovementsControllerSpec.scala
@@ -5603,7 +5603,7 @@ class V2MovementsControllerSpec
           val request =
             FakeRequest(
               "GET",
-              v2.controllers.routes.V2MovementsController.getMessageBody(movementType, movementId, messageId).url,
+              routing.routes.GenericRouting.getMessageBody(movementType, movementId, messageId).url,
               headers,
               Source.empty[ByteString]
             )

--- a/test/v2_1/controllers/V2MovementsControllerSpec.scala
+++ b/test/v2_1/controllers/V2MovementsControllerSpec.scala
@@ -5604,7 +5604,7 @@ class V2MovementsControllerSpec
           val request =
             FakeRequest(
               "GET",
-              v2.controllers.routes.V2MovementsController.getMessageBody(movementType, movementId, messageId).url,
+              routing.routes.GenericRouting.getMessageBody(movementType, movementId, messageId).url,
               headers,
               Source.empty[ByteString]
             )


### PR DESCRIPTION
During testing of the v2.1 routing it was noticed that one of the endpoints did not have the correct routing in place. 